### PR TITLE
Check if locale is in the url, if so, remove it

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 HTTP_SESSION_ID_REGEX = re.compile(
     r'^SID:(?P<type>(?:ANON|AUTH)):(?P<realm>.*?):(?P<session_id>.+?)(?:[-:][0-9a-fA-F]+){0,2}$')
 
+LANGUAGE_IN_URL = re.compile(r'(/[^/]*)(/.*$)')
+
+
+def remove_locale_from_url(url):
+    """
+    Removes locale from url.
+
+    >>> url = "http://localhost/nl-nl/api/basket"
+    >>> remove_language_from_url(url)
+    'http://localhost/nl-nl/api/basket'
+    >>>
+    >>> url = "http://localhost/api/basket"
+    >>> remove_language_from_url(url)
+    'http://localhost/api/basket'
+    """
+
+    i18n = LANGUAGE_IN_URL.match(url)
+    return i18n.groups()[1] if i18n else url
+
 
 def parse_session_id(request):
     """
@@ -80,8 +99,8 @@ def start_or_resume(session_id, session_type):
 
 
 def is_api_request(request):
-    path = request.path.lower()
-    api_root = reverse('api-root').lower()
+    path = remove_locale_from_url(request.path.lower())
+    api_root = remove_locale_from_url(reverse('api-root').lower())
     return path.startswith(api_root)
 
 


### PR DESCRIPTION
When i18n is enabled in Django it sometimes occures that `reverse('root-api')` returns an url including a different locale then the current locale. Why this happens is unknown, it's something in the i18n code in Django and it's really hard to reproduce.

The problem is that when it occurs, the `is_api_request()` call returns False, so the session which is build up by the `Session-Id` header is not resumed, instead a normal django session is initiated. When you retrieve your basket using the API you will get a different one as it cannot find it in your session.

See this debug log what happens:
```
DEBUG 2015-02-13 11:41:20,639 middleware >> NO API request -> path:/nl-nl/api/basket/ api_root:/fr-be/api/
DEBUG 2015-02-13 11:41:20,639 middleware >> NO API request, using normal session middleware
DEBUG 2015-02-13 11:41:20,652 abstract_models Session basket info:SID:ANON:shop-api.myshop.com:{cfa69238-4f46-47d6-9ed8-0f8a75e14eee} -> key:None contents:{}
```
The session key will result in `None` so it won't return the correct basket.

As the locale is irrelevant to check if it's an api request, this code will remove the language from the url's prior to comparison.