### PR TITLE
Remove locale from url

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -8,11 +8,13 @@ from django.http.response import HttpResponse
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions
 from rest_framework import authentication
+from django.conf import settings
 
 from oscarapi.utils import (
     get_domain,
     session_id_from_parsed_session_uri,
-    get_session
+    get_session,
+    i18n_path_regex
 )
 from oscarapi import models
 
@@ -21,27 +23,17 @@ logger = logging.getLogger(__name__)
 HTTP_SESSION_ID_REGEX = re.compile(
     r'^SID:(?P<type>(?:ANON|AUTH)):(?P<realm>.*?):(?P<session_id>.+?)(?:[-:][0-9a-fA-F]+){0,2}$')
 
-LANGUAGE_IN_URL = re.compile(r'(/[a-z][a-z]-[a-z][a-z])(/.*$)')
+LANGUAGE_IN_PATH = i18n_path_regex()
 
 
 def remove_locale_from_path(path):
     """
     Removes locale from path.
-
-    >>> path = "/nl-nl/api/basket"
-    >>> remove_locale_from_path(path)
-    '/api/basket'
-    >>>
-    >>> path = "/nl-nl/api/basket/20/lines"
-    >>> remove_locale_from_path(path)
-    '/api/basket/20/lines'
-    >>>
-    >>> path = "/api/basket"
-    >>> remove_locale_from_path(path)
-    '/api/basket'
     """
-    i18n = LANGUAGE_IN_URL.match(path)
-    return i18n.groups()[1] if i18n else path
+    if settings.USE_I18N:
+        i18n = LANGUAGE_IN_PATH.match(path)
+        return i18n.groups()[1] if i18n else path
+    return path
 
 
 def parse_session_id(request):

--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 HTTP_SESSION_ID_REGEX = re.compile(
     r'^SID:(?P<type>(?:ANON|AUTH)):(?P<realm>.*?):(?P<session_id>.+?)(?:[-:][0-9a-fA-F]+){0,2}$')
 
+LANGUAGE_IN_URL = re.compile(r'(/[^/]*)(/.*$)')
+
+
+def remove_locale_from_url(url):
+    """
+    Removes locale from url.
+
+    >>> url = "http://localhost/nl-nl/api/basket"
+    >>> remove_language_from_url(url)
+    'http://localhost/nl-nl/api/basket'
+    >>>
+    >>> url = "http://localhost/api/basket"
+    >>> remove_language_from_url(url)
+    'http://localhost/api/basket'
+    """
+
+    i18n = LANGUAGE_IN_URL.match(url)
+    return i18n.groups()[1] if i18n else url
+
 
 def parse_session_id(request):
     """
@@ -80,8 +99,8 @@ def start_or_resume(session_id, session_type):
 
 
 def is_api_request(request):
-    path = request.path.lower()
-    api_root = reverse('api-root').lower()
+    path = remove_locale_from_url(request.path.lower())
+    api_root = remove_locale_from_url(reverse('api-root').lower())
     return path.startswith(api_root)
 
 

--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -21,24 +21,27 @@ logger = logging.getLogger(__name__)
 HTTP_SESSION_ID_REGEX = re.compile(
     r'^SID:(?P<type>(?:ANON|AUTH)):(?P<realm>.*?):(?P<session_id>.+?)(?:[-:][0-9a-fA-F]+){0,2}$')
 
-LANGUAGE_IN_URL = re.compile(r'(/[^/]*)(/.*$)')
+LANGUAGE_IN_URL = re.compile(r'(/[a-z][a-z]-[a-z][a-z])(/.*$)')
 
 
-def remove_locale_from_url(url):
+def remove_locale_from_path(path):
     """
-    Removes locale from url.
+    Removes locale from path.
 
-    >>> url = "http://localhost/nl-nl/api/basket"
-    >>> remove_language_from_url(url)
-    'http://localhost/nl-nl/api/basket'
+    >>> path = "/nl-nl/api/basket"
+    >>> remove_locale_from_path(path)
+    '/api/basket'
     >>>
-    >>> url = "http://localhost/api/basket"
-    >>> remove_language_from_url(url)
-    'http://localhost/api/basket'
+    >>> path = "/nl-nl/api/basket/20/lines"
+    >>> remove_locale_from_path(path)
+    '/api/basket/20/lines'
+    >>>
+    >>> path = "/api/basket"
+    >>> remove_locale_from_path(path)
+    '/api/basket'
     """
-
-    i18n = LANGUAGE_IN_URL.match(url)
-    return i18n.groups()[1] if i18n else url
+    i18n = LANGUAGE_IN_URL.match(path)
+    return i18n.groups()[1] if i18n else path
 
 
 def parse_session_id(request):
@@ -99,8 +102,8 @@ def start_or_resume(session_id, session_type):
 
 
 def is_api_request(request):
-    path = remove_locale_from_url(request.path.lower())
-    api_root = remove_locale_from_url(reverse('api-root').lower())
+    path = remove_locale_from_path(request.path.lower())
+    api_root = remove_locale_from_path(reverse('api-root').lower())
     return path.startswith(api_root)
 
 

--- a/oscarapi/utils.py
+++ b/oscarapi/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 
 from django.conf import settings
 from django.contrib import auth
@@ -110,3 +111,20 @@ def get_session(session_id, raise_on_create=False):
             session.save(must_create=True)
 
     return session
+
+
+def i18n_path_regex():
+    """
+    Returns a regex which matches the language prefixes generated
+    by i18n_patterns from settings.LANGUAGES
+
+    >>> path = "/{0}/api/basket".format(settings.LANGUAGES[0][0])
+    >>> regex = i18n_path_regex()
+    >>> match = regex.match(path)
+    >>> match.groups()[1]
+    '/api/basket'
+    """
+    language_keys = dict(settings.LANGUAGES).keys()
+    matchstring = "|".join(language_keys)
+    return re.compile(
+        r'(/(?:{0}))(/.*$)'.format(matchstring).lower())


### PR DESCRIPTION
When i18n is enabled in Django it sometimes occures that `reverse('root-api')` returns an url including a different locale then the current locale. Why this happens is unknown, it's something in the i18n code in Django and it's really hard to reproduce.

The problem is that when it occurs, the `is_api_request()` call returns False, so the session which is build up by the `Session-Id` header is not resumed, instead a normal django session is initiated. When you retrieve your basket using the API you will get a different one as it cannot find it in your (already existing) session (which is created using the middleware).

See this debug log what happens:
```
DEBUG 2015-02-13 11:41:20,639 middleware >> NO API request -> path:/nl-nl/api/basket/ api_root:/fr-be/api/
DEBUG 2015-02-13 11:41:20,639 middleware >> NO API request, using normal session middleware
DEBUG 2015-02-13 11:41:20,652 abstract_models Session basket info:SID:ANON:shop-api.myshop.com:{cfa69238-4f46-47d6-9ed8-0f8a75e14eee} -> key:None contents:{}
```
The session key will result in `None` so it won't return the correct basket.

As the locale is irrelevant to check if it's an api request, this code will remove the language from the url's prior to comparison.