### PR TITLE
Fixed the OscarSerializer field_mapping overing, was raising a TypeError

### DIFF
--- a/oscarapi/basket/operations.py
+++ b/oscarapi/basket/operations.py
@@ -26,7 +26,7 @@ Selector = None
 def apply_offers(request, basket):
     "Apply offers and discounts to cart"
     if not basket.is_empty:
-        Applicator().apply(request, basket)
+        Applicator().apply(basket, request)
 
 
 def prepare_basket(basket, request):

--- a/oscarapi/utils.py
+++ b/oscarapi/utils.py
@@ -18,10 +18,11 @@ def overridable(name, default):
 
 
 class OscarSerializer(object):
-    field_mapping = dict(
-        serializers.ModelSerializer.serializer_field_mapping, **{
-            oscar.models.fields.NullCharField: serializers.CharField
-        })
+    field_mapping = serializers.ModelSerializer.serializer_field_mapping.copy()
+    null_char_field_mapping = {
+        oscar.models.fields.NullCharField: serializers.CharField}
+
+    field_mapping.update(null_char_field_mapping)
 
     def to_native(self, obj):
         num_fields = len(self.get_fields())


### PR DESCRIPTION
OscarSerializer was extending the field_mapping dictionary by passing
in another dict as a kwarg. At least on my system this was raising a
TypeError stating that keys must be strings.

I've updated the method used to be more explicit (still does the same
thing under the hood).