### PR TITLE
Fix Keyword Arguments error in Python 3.5

### DIFF
--- a/oscarapi/utils.py
+++ b/oscarapi/utils.py
@@ -17,13 +17,17 @@ def overridable(name, default):
     return getattr(settings, name, default)
 
 
-field_mapping = serializers.ModelSerializer.serializer_field_mapping
-field_mapping.update({
-    oscar.models.fields.NullCharField: serializers.CharField
-})
+def expand_field_mapping(extra_fields):
+    # This doesn't make a copy
+    field_mapping = serializers.ModelSerializer.serializer_field_mapping
+    field_mapping.update(extra_fields)
+    return field_mapping
+
 
 class OscarSerializer(object):
-    field_mapping = field_mapping
+    field_mapping = expand_field_mapping({
+        oscar.models.fields.NullCharField: serializers.CharField
+    })
 
     def __init__(self, *args, **kwargs):
         """

--- a/oscarapi/utils.py
+++ b/oscarapi/utils.py
@@ -17,11 +17,13 @@ def overridable(name, default):
     return getattr(settings, name, default)
 
 
+field_mapping = serializers.ModelSerializer.serializer_field_mapping
+field_mapping.update({
+    oscar.models.fields.NullCharField: serializers.CharField
+})
+
 class OscarSerializer(object):
-    field_mapping = dict(
-        serializers.ModelSerializer.serializer_field_mapping, **{
-            oscar.models.fields.NullCharField: serializers.CharField
-        })
+    field_mapping = field_mapping
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
In Python 3, the method used to extend the field mappings dictionary threw an
exception because keyword arguments must be strings. This commit fixes that
exception.