### PR TITLE
Fix basket serializer when tax is not known

### DIFF
--- a/oscarapi/serializers/basket.py
+++ b/oscarapi/serializers/basket.py
@@ -103,10 +103,12 @@ class BasketLineSerializer(OscarHyperlinkedModelSerializer):
         many=True, fields=('url', 'option', 'value'), required=False)
     price_excl_tax = serializers.DecimalField(decimal_places=2, max_digits=12,
                                               source='line_price_excl_tax_incl_discounts')
-    price_incl_tax = serializers.DecimalField(decimal_places=2, max_digits=12,
-                                              source='line_price_incl_tax_incl_discounts')
-    price_incl_tax_excl_discounts = serializers.DecimalField(
+    price_incl_tax = TaxIncludedDecimalField(decimal_places=2, max_digits=12,
+                                             excl_tax_field='line_price_excl_tax_incl_discounts',
+                                             source='line_price_incl_tax_incl_discounts')
+    price_incl_tax_excl_discounts = TaxIncludedDecimalField(
         decimal_places=2, max_digits=12,
+        excl_tax_field='line_price_excl_tax',
         source='line_price_incl_tax')
     price_excl_tax_excl_discounts = serializers.DecimalField(
         decimal_places=2, max_digits=12,
@@ -120,7 +122,7 @@ class BasketLineSerializer(OscarHyperlinkedModelSerializer):
             'url', 'product', 'quantity', 'attributes', 'price_currency',
             'price_excl_tax', 'price_incl_tax',
             'price_incl_tax_excl_discounts', 'price_excl_tax_excl_discounts',
-            'warning', 'basket', 'stockrecord', 'date_created'
+            'is_tax_known', 'warning', 'basket', 'stockrecord', 'date_created'
         ])
 
 class LineSerializer(serializers.HyperlinkedModelSerializer):

--- a/oscarapi/serializers/basket.py
+++ b/oscarapi/serializers/basket.py
@@ -1,12 +1,12 @@
 import logging
 from rest_framework import serializers
-from rest_framework.fields import get_attribute
 
 from oscarapi.utils import (
     overridable,
     OscarModelSerializer,
     OscarHyperlinkedModelSerializer,
 )
+from oscarapi.serializers.fields import TaxIncludedDecimalField
 from django.utils.translation import ugettext as _
 from oscar.core.loading import get_model
 from decimal import Decimal
@@ -37,20 +37,6 @@ class OfferDiscountSerializer(serializers.Serializer):
 
 class VoucherDiscountSerializer(OfferDiscountSerializer):
     voucher = VoucherSerializer(required=False)
-
-
-class TaxIncludedDecimalField(serializers.DecimalField):
-    def __init__(self, excl_tax_field=None, excl_tax_value=None, *args, **kwargs):
-        self.excl_tax_field = excl_tax_field
-        self.excl_tax_value = excl_tax_value
-        super(TaxIncludedDecimalField, self).__init__(*args, **kwargs)
-
-    def get_attribute(self, instance):
-        if instance.is_tax_known:
-            return super(TaxIncludedDecimalField, self).get_attribute(instance)
-        if self.excl_tax_field:
-            return get_attribute(instance, (self.excl_tax_field, ))
-        return self.excl_tax_value
 
 
 class BasketSerializer(serializers.HyperlinkedModelSerializer):

--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -19,6 +19,8 @@ from oscarapi.utils import (
     OscarModelSerializer,
     overridable
 )
+from oscarapi.serializers.fields import TaxIncludedDecimalField
+
 
 OrderPlacementMixin = get_class('checkout.mixins', 'OrderPlacementMixin')
 OrderTotalCalculator = get_class('checkout.calculators',
@@ -39,9 +41,11 @@ class PriceSerializer(serializers.Serializer):
         max_length=12, default=settings.OSCAR_DEFAULT_CURRENCY, required=False)
     excl_tax = serializers.DecimalField(
         decimal_places=2, max_digits=12, required=True)
-    incl_tax = serializers.DecimalField(
+    incl_tax = TaxIncludedDecimalField(
+        excl_tax_field='excl_tax',
         decimal_places=2, max_digits=12, required=False)
-    tax = serializers.DecimalField(
+    tax = TaxIncludedDecimalField(
+        excl_tax_value='0.00',
         decimal_places=2, max_digits=12, required=False)
 
 

--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from rest_framework.fields import get_attribute
+
+
+class TaxIncludedDecimalField(serializers.DecimalField):
+    def __init__(self, excl_tax_field=None, excl_tax_value=None, *args, **kwargs):
+        self.excl_tax_field = excl_tax_field
+        self.excl_tax_value = excl_tax_value
+        super(TaxIncludedDecimalField, self).__init__(*args, **kwargs)
+
+    def get_attribute(self, instance):
+        if instance.is_tax_known:
+            return super(TaxIncludedDecimalField, self).get_attribute(instance)
+        if self.excl_tax_field:
+            return get_attribute(instance, (self.excl_tax_field, ))
+        return self.excl_tax_value


### PR DESCRIPTION
When using the US strategy, tax isn't know until the shipping address is
entered. This causes BasketSerializer to throw an exception because access the
total_incl_tax, total_incl_tax_excl_discounts, or total_tax properties throw
TaxNotKnown when is_tax_known is false. This fixes the issue by detecting that
case and acknowledging in the API that tax isn't yet known.