### PR TITLE
Add Docker configuration for testing convenience 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.5
+ENV PYTHONUNBUFFERED 0
+
+# Set Code Dir
+RUN mkdir /code
+WORKDIR /code
+
+# Install Django
+RUN pip install Django==1.9.1
+
+# Add source
+ADD . /code/
+
+# Install other deps
+RUN make install
+
+# Run tests
+CMD make test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+test:
+  build: .
+  volumes:
+    - .:/code


### PR DESCRIPTION
Just for developer convenience, it's nice to have this set up. Makes messing with other versions of Python or misc libraries easier and prevents having to deal with a virtualenv.