### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ This package provides a RESTful API for `django-oscar`_.
 
 .. image:: https://readthedocs.org/projects/django-oscar-api/badge/
    :alt: Documentation Status
-   :target: http://django-oscar-api.readthedocs.org/
+   :target: https://django-oscar-api.readthedocs.io/
 
 .. image:: https://img.shields.io/pypi/v/django-oscar-api.svg
    :alt: Latest PyPi release
@@ -43,7 +43,7 @@ steps:
 
 See the Documentation_ for more information.
 
-.. _Documentation: https://django-oscar-api.readthedocs.org
+.. _Documentation: https://django-oscar-api.readthedocs.io
 
 Changelog
 =========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Installation
 ------------
 Please see the installation instructions of `Oscar`_ to install Oscar and how to create your own project. Then you can install Oscar API by simply typing:
 
-.. _`Oscar`: http://django-oscar.readthedocs.org/en/releases-1.1/internals/getting_started.html
+.. _`Oscar`: https://django-oscar.readthedocs.io/en/releases-1.1/internals/getting_started.html
 
 .. code-block:: bash
 

--- a/docs/source/usage/customizing_oscarapi.rst
+++ b/docs/source/usage/customizing_oscarapi.rst
@@ -7,7 +7,7 @@ By using the `django-rest-framework`_ life has become easy, at least for customi
 .. note::
     In oscar you can `fork an app`_ to easily customize only the things you want to change.
 
-.. _`fork an app`: http://django-oscar.readthedocs.org/en/releases-1.1/topics/fork_app.html
+.. _`fork an app`: https://django-oscar.readthedocs.io/en/releases-1.1/topics/fork_app.html
 .. _`django-rest-framework`: http://www.django-rest-framework.org
 
 Oscar API is using the basics of this so you can see Oscar API as one of the apps you customized just like in Oscar. Each Oscar app (or forked app) has a ``app.py`` which manages the url's to your custom views. 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.