### PR TITLE
Change process_response to have API-created basket cookie added to response

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -215,8 +215,9 @@ class ApiBasketMiddleWare(BasketMiddleware, IsApiRequest):
                     store_basket_in_session(basket, request.session)
 
     def process_response(self, request, response):
-        if self.is_api_request(request) and hasattr(request, 'user'):
-            # at this point we are sure a basket can be found in the session,
+        if self.is_api_request(request) and hasattr(request, 'user') and request.session:
+            # at this point we are sure a basket can be found in the session
+            # (if the session hasn't been destroyed by logging out),
             # because it is enforced in process_request.
             # We just have to make sure it is stored as a cookie, because it
             # could have been created by oscarapi.


### PR DESCRIPTION
This tries to fix #34. The problem is that adding the basket cookie to request tricks the super call in thinking that the cookie is already there. This is because of has_basket_cookie in the [super call](https://github.com/django-oscar/django-oscar/blob/913da107f1f760a707a0555d06663fc5dbcea4b2/src/oscar/apps/basket/middleware.py):
```
    def process_response(self, request, response):
        ...
        # Check if we need to set a cookie. If the cookies is already available
        # but is set in the cookies_to_delete list then we need to re-set it.
        has_basket_cookie = (
            cookie_key in request.COOKIES
            and cookie_key not in cookies_to_delete)

        # If a basket has had products added to it, but the user is anonymous
        # then we need to assign it to a cookie
        if (request.basket.id and not request.user.is_authenticated()
                and not has_basket_cookie):
        ...
```
I haven't found a better way than just rewrite and streamline part of the super call in ApiBasketMiddleware.process_response and skip the super call altogheter. I know this is not optimal but I couldn't find a better way.