### PR TITLE
Use configured serializer in stead of the hardcoded one

### DIFF
--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -60,7 +60,7 @@ class LoginView(APIView):
         anonymous_basket.delete()
 
     def post(self, request, format=None):
-        ser = serializers.LoginSerializer(data=request.data)
+        ser = serializer_class(data=request.data)
         if ser.is_valid():
 
             anonymous_basket = operations.get_anonymous_basket(request)

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -60,7 +60,7 @@ class LoginView(APIView):
         anonymous_basket.delete()
 
     def post(self, request, format=None):
-        ser = serializer_class(data=request.data)
+        ser = self.serializer_class(data=request.data)
         if ser.is_valid():
 
             anonymous_basket = operations.get_anonymous_basket(request)


### PR DESCRIPTION
The login serializer looks as if it is configurable, but in fact the configured serializer class is never used.