### PR TITLE
basket/shipping-methods could use another basket than /basket

### DIFF
--- a/oscarapi/views/basket.py
+++ b/oscarapi/views/basket.py
@@ -164,7 +164,7 @@ def shipping_methods(request, format=None):
     """
     basket = get_basket(request)
     shiping_methods = Repository().get_shipping_methods(
-        basket=request.basket, user=request.user,
+        basket=basket, user=request.user,
         request=request)
     ser = serializers.ShippingMethodSerializer(
         shiping_methods, many=True, context={'basket': basket})


### PR DESCRIPTION
There is a case when request.basket is empty, but get_basket(request) will return a basket with products based on the cookies