### PR TITLE
Check if the given object is a basket in `request_contains_basket`

### DIFF
--- a/oscarapi/basket/operations.py
+++ b/oscarapi/basket/operations.py
@@ -109,11 +109,12 @@ def store_basket_in_session(basket, session):
 
 
 def request_contains_basket(request, basket):
-    if basket.can_be_edited:
-        if request.user.is_authenticated():
-            return request.user == basket.owner
+    if isinstance(basket, Basket):
+        if basket.can_be_edited:
+            if request.user.is_authenticated():
+                return request.user == basket.owner
 
-        return get_basket_id_from_session(request) == basket.pk
+            return get_basket_id_from_session(request) == basket.pk
 
     return False
 


### PR DESCRIPTION
Why?

Because We use the following mixin for the `LineList` view and for the `Checkout` view:

```python
class BasketPermissionMixin(object):
    """
    This mixins adds some methods that can be used to check permissions
    on a basket instance.
    """
    # The permission class is mainly used to check Basket permission!
    permission_classes = (permissions.IsAdminUserOrRequestContainsBasket,)
```

So, when doing a checkout (I could only reproduce this with the `BrowsableAPI` of `djangorestframework` because of https://github.com/encode/django-rest-framework/blob/master/rest_framework/renderers.py#L431), it will check the object permissions according to http://www.django-rest-framework.org/api-guide/permissions/#object-level-permissions

But in case of the `CheckoutView`, it will check permissions of an order object, not a basket, which will raise an `AttributeError` on `can_be_edited` (because it's not a basket):

```python
def request_contains_basket(request, basket):
    if basket.can_be_edited:
        if request.user.is_authenticated():
            return request.user == basket.owner

        return get_basket_id_from_session(request) == basket.pk

    return False
```
So checking first if we have a basket anyway would be the most simple solution to fix this.
 

