### PR TITLE
No need to delete the merged anonymous basket after merge

### DIFF
--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -54,6 +54,10 @@ class LoginView(APIView):
 
         raise MethodNotAllowed('GET')
 
+    def merge_baskets(self, anonymous_basket, basket):
+        "Hook to enforce rules when merging baskets."
+        basket.merge(anonymous_basket)
+
     def post(self, request, format=None):
         ser = serializers.LoginSerializer(data=request.data)
         if ser.is_valid():
@@ -76,7 +80,7 @@ class LoginView(APIView):
             # merge anonymous basket with authenticated basket.
             basket = operations.get_user_basket(user)
             if anonymous_basket is not None:
-                basket.merge(anonymous_basket)
+                self.merge_baskets(anonymous_basket, basket)
 
             operations.store_basket_in_session(basket, request.session)
 

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -54,11 +54,6 @@ class LoginView(APIView):
 
         raise MethodNotAllowed('GET')
 
-    def merge_baskets(self, anonymous_basket, basket):
-        "Hook to enforce rules when merging baskets."
-        basket.merge(anonymous_basket)
-        anonymous_basket.delete()
-
     def post(self, request, format=None):
         ser = serializers.LoginSerializer(data=request.data)
         if ser.is_valid():
@@ -81,7 +76,7 @@ class LoginView(APIView):
             # merge anonymous basket with authenticated basket.
             basket = operations.get_user_basket(user)
             if anonymous_basket is not None:
-                self.merge_baskets(anonymous_basket, basket)
+                basket.merge(anonymous_basket)
 
             operations.store_basket_in_session(basket, request.session)
 


### PR DESCRIPTION
For some reason the merged basket was deleted but oscar already has a status for that - MERGED. It makes super difficult to debug complex cases if anonymous basket got deleted.