### PR TITLE
oscarapi now correctly keeps the types of product attributes as defined in the ProductType.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
 env:
     - DJANGO=Django==1.8.18 OSCAR=django-oscar==1.5.1
     - DJANGO=Django==1.10.8 OSCAR=django-oscar==1.5.1
-    - DJANGO=Django==1.11.8 OSCAR=django-oscar==1.5.1
+    - DJANGO=Django==1.11.9 OSCAR=django-oscar==1.5.1
 
 before_install:
     - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,7 @@ python:
     - '3.6'
 
 env:
-    - DJANGO=Django==1.8.18 OSCAR=django-oscar==1.2.2
-    - DJANGO=Django==1.8.18 OSCAR=django-oscar==1.3
-    - DJANGO=Django==1.8.18 OSCAR=django-oscar==1.4
     - DJANGO=Django==1.8.18 OSCAR=django-oscar==1.5.1
-    - DJANGO=Django==1.10.8 OSCAR=django-oscar==1.4
     - DJANGO=Django==1.10.8 OSCAR=django-oscar==1.5.1
     - DJANGO=Django==1.11.8 OSCAR=django-oscar==1.5.1
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,14 @@
 =========
 Changelog
 =========
+1.3.0 (2018-01-16)
+------------------
+Features:
+  * Better support for the different ProductAttribute types in the serializer (including Entity when you implement a `.json()` method on your model)
+
+Notes:
+  Dropped support for Oscar versions < 1.5(as we support new features which are available since oscar 1.5)
+
 1.2.1 (2017-12-15)
 -------------------
 Fixes:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,16 +13,16 @@ This package provides a RESTful API for `django-oscar`_, it's based on `django-r
 
 Requirements:
 -------------
-Currently Oscar API is compatbile with python 2.7 / 3.5 / 3.6 and the following django versions:
+This version of Oscar API is compatbile with python 2.7 / 3.5 / 3.6 and the following django versions:
 
 Django 1.8:
 ~~~~~~~~~~~
-- Oscar 1.2.2 / 1.3 / 1.4 and 1.5.1
+- Oscar 1.5.1
 - requires `djangorestframework<3.7`, and `django-tables2<1.17.0`
 
 Django 1.10:
 ~~~~~~~~~~~~
-- Osccar 1.4 and 1.5.1
+- Osccar 1.5.1
 - requires `djangorestframework>=3.4`
 
 Django 1.11:
@@ -49,16 +49,6 @@ Please see the installation instructions of `Oscar`_ to install Oscar and how to
     $ pip install django-oscar-api
 
 Or you could add ``django-oscar-api`` to your project dependencies.
-
-.. warning::
-
-    If you want to install Django Oscar API with Oscar 1.5.0, you'll need to use the following command:
-    
-    .. code-block:: bash
-
-        $ pip install django-oscar-api[django_1_11]
-
-    This is because of wrong dependency specifications in version 1.5.0. This is fixed in Oscar 1.5.1
 
 .. note::
 

--- a/oscarapi/fixtures/attributeoption.xml
+++ b/oscarapi/fixtures/attributeoption.xml
@@ -4,4 +4,8 @@
         <field to="catalogue.attributeoptiongroup" name="group" rel="ManyToOneRel">1</field>
         <field type="CharField" name="option">Small</field>
     </object>
+    <object pk="2" model="catalogue.attributeoption">
+        <field to="catalogue.attributeoptiongroup" name="group" rel="ManyToOneRel">1</field>
+        <field type="CharField" name="option">Large</field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/product.xml
+++ b/oscarapi/fixtures/product.xml
@@ -36,4 +36,18 @@
         <field type="BooleanField" name="is_discountable">True</field>
         <field to="catalogue.option" name="product_options" rel="ManyToManyRel"/>
     </object>
+    <object model="catalogue.product" pk="3">
+        <field name="structure" type="CharField">standalone</field>
+        <field name="upc" type="CharField">attrtypestest</field>
+        <field name="parent" rel="ManyToOneRel" to="catalogue.product"><None></None></field>
+        <field name="title" type="CharField">lots of attributes</field>
+        <field name="slug" type="SlugField">lots-of-attributes</field>
+        <field name="description" type="TextField">&lt;p&gt;It is a test for the attributes&lt;/p&gt;</field>
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="rating" type="FloatField"><None></None></field>
+        <field name="date_created" type="DateTimeField">2018-01-15T14:20:56.580321+00:00</field>
+        <field name="date_updated" type="DateTimeField">2018-01-15T14:22:13.099126+00:00</field>
+        <field name="is_discountable" type="BooleanField">True</field>
+        <field name="product_options" rel="ManyToManyRel" to="catalogue.option"></field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/product.xml
+++ b/oscarapi/fixtures/product.xml
@@ -50,4 +50,18 @@
         <field name="is_discountable" type="BooleanField">True</field>
         <field name="product_options" rel="ManyToManyRel" to="catalogue.option"></field>
     </object>
+    <object model="catalogue.product" pk="4">
+        <field name="structure" type="CharField">standalone</field>
+        <field name="upc" type="CharField">entity</field>
+        <field name="parent" rel="ManyToOneRel" to="catalogue.product"><None></None></field>
+        <field name="title" type="CharField">Entity product</field>
+        <field name="slug" type="SlugField">entity-product</field>
+        <field name="description" type="TextField">&lt;p&gt;An entity&lt;/p&gt;</field>
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">3</field>
+        <field name="rating" type="FloatField"><None></None></field>
+        <field name="date_created" type="DateTimeField">2018-01-16T08:51:30.405895+00:00</field>
+        <field name="date_updated" type="DateTimeField">2018-01-16T08:51:30.405937+00:00</field>
+        <field name="is_discountable" type="BooleanField">True</field>
+        <field name="product_options" rel="ManyToManyRel" to="catalogue.option"></field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productattribute.xml
+++ b/oscarapi/fixtures/productattribute.xml
@@ -96,4 +96,12 @@
         <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
         <field name="required" type="BooleanField">False</field>
     </object>
+    <object model="catalogue.productattribute" pk="13">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">3</field>
+        <field name="name" type="CharField">entity</field>
+        <field name="code" type="SlugField">entity</field>
+        <field name="type" type="CharField">entity</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productattribute.xml
+++ b/oscarapi/fixtures/productattribute.xml
@@ -8,4 +8,92 @@
         <field to="catalogue.attributeoptiongroup" name="option_group" rel="ManyToOneRel">1</field>
         <field type="BooleanField" name="required">True</field>
     </object>
+    <object model="catalogue.productattribute" pk="2">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">text</field>
+        <field name="code" type="SlugField">text</field>
+        <field name="type" type="CharField">text</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="3">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">integer</field>
+        <field name="code" type="SlugField">integer</field>
+        <field name="type" type="CharField">integer</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="4">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">boolean</field>
+        <field name="code" type="SlugField">boolean</field>
+        <field name="type" type="CharField">boolean</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="5">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">float</field>
+        <field name="code" type="SlugField">float</field>
+        <field name="type" type="CharField">float</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="6">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">html</field>
+        <field name="code" type="SlugField">html</field>
+        <field name="type" type="CharField">richtext</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="7">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">date</field>
+        <field name="code" type="SlugField">date</field>
+        <field name="type" type="CharField">date</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="8">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">datetime</field>
+        <field name="code" type="SlugField">datetime</field>
+        <field name="type" type="CharField">datetime</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="9">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">option</field>
+        <field name="code" type="SlugField">option</field>
+        <field name="type" type="CharField">option</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup">1</field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="10">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">multioption</field>
+        <field name="code" type="SlugField">multioption</field>
+        <field name="type" type="CharField">multi_option</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup">1</field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="11">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">file</field>
+        <field name="code" type="SlugField">file</field>
+        <field name="type" type="CharField">file</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
+    <object model="catalogue.productattribute" pk="12">
+        <field name="product_class" rel="ManyToOneRel" to="catalogue.productclass">2</field>
+        <field name="name" type="CharField">image</field>
+        <field name="code" type="SlugField">image</field>
+        <field name="type" type="CharField">image</field>
+        <field name="option_group" rel="ManyToOneRel" to="catalogue.attributeoptiongroup"><None></None></field>
+        <field name="required" type="BooleanField">False</field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productattributevalue.xml
+++ b/oscarapi/fixtures/productattributevalue.xml
@@ -218,4 +218,21 @@
         <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
         <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
     </object>
+    <object model="catalogue.productattributevalue" pk="13">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">13</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">4</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><natural>auth</natural><natural>user</natural></field>
+        <field name="entity_object_id" type="PositiveIntegerField">1</field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productattributevalue.xml
+++ b/oscarapi/fixtures/productattributevalue.xml
@@ -31,4 +31,191 @@
             <None/>
         </field>
     </object>
+    <object model="catalogue.productattributevalue" pk="2">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">4</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField">True</field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="3">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">7</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField">2018-01-02</field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="4">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">8</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField">2018-01-02T10:45:00+00:00</field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="5">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">11</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField">images/products/2018/01/sony-xa50ES.pdf</field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="6">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">5</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField">3.2</field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="7">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">6</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField">&lt;p&gt;I &lt;strong&gt;am&lt;/strong&gt; a test&lt;/p&gt;</field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="8">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">12</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField">images/products/2018/01/IMG_3777.JPG</field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="9">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">3</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField">7</field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="10">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">10</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"><object pk="1"></object><object pk="2"></object></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="11">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">9</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField"><None></None></field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption">1</field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
+    <object model="catalogue.productattributevalue" pk="12">
+        <field name="attribute" rel="ManyToOneRel" to="catalogue.productattribute">2</field>
+        <field name="product" rel="ManyToOneRel" to="catalogue.product">3</field>
+        <field name="value_text" type="TextField">I am some kind of text</field>
+        <field name="value_integer" type="IntegerField"><None></None></field>
+        <field name="value_boolean" type="NullBooleanField"><None></None></field>
+        <field name="value_float" type="FloatField"><None></None></field>
+        <field name="value_richtext" type="TextField"><None></None></field>
+        <field name="value_date" type="DateField"><None></None></field>
+        <field name="value_datetime" type="DateTimeField"><None></None></field>
+        <field name="value_option" rel="ManyToOneRel" to="catalogue.attributeoption"><None></None></field>
+        <field name="value_file" type="FileField"></field>
+        <field name="value_image" type="FileField"></field>
+        <field name="entity_content_type" rel="ManyToOneRel" to="contenttypes.contenttype"><None></None></field>
+        <field name="entity_object_id" type="PositiveIntegerField"><None></None></field>
+        <field name="value_multi_option" rel="ManyToManyRel" to="catalogue.attributeoption"></field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productclass.xml
+++ b/oscarapi/fixtures/productclass.xml
@@ -14,4 +14,11 @@
         <field name="track_stock" type="BooleanField">True</field>
         <field name="options" rel="ManyToManyRel" to="catalogue.option"></field>
     </object>
+    <object model="catalogue.productclass" pk="3">
+        <field name="name" type="CharField">EntityProduct</field>
+        <field name="slug" type="SlugField">entityproduct</field>
+        <field name="requires_shipping" type="BooleanField">True</field>
+        <field name="track_stock" type="BooleanField">True</field>
+        <field name="options" rel="ManyToManyRel" to="catalogue.option"></field>
+    </object>
 </django-objects>

--- a/oscarapi/fixtures/productclass.xml
+++ b/oscarapi/fixtures/productclass.xml
@@ -7,4 +7,11 @@
         <field type="BooleanField" name="track_stock">True</field>
         <field to="catalogue.option" name="options" rel="ManyToManyRel"/>
     </object>
+    <object model="catalogue.productclass" pk="2">
+        <field name="name" type="CharField">TestType</field>
+        <field name="slug" type="SlugField">testtype</field>
+        <field name="requires_shipping" type="BooleanField">True</field>
+        <field name="track_stock" type="BooleanField">True</field>
+        <field name="options" rel="ManyToManyRel" to="catalogue.option"></field>
+    </object>
 </django-objects>

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.utils.translation import ugettext as _
 
 from oscarapi.utils import (
     OscarModelSerializer,
@@ -56,6 +57,17 @@ class ProductAttributeValueSerializer(OscarModelSerializer):
             return obj.value.url
         elif obj_type == ProductAttribute.IMAGE:
             return obj.value.url
+        elif obj_type == ProductAttribute.ENTITY:
+            if hasattr(obj.value, 'json'):
+                return obj.value.json()
+            else:
+                return _(
+                    "%(entity)s has no json method, can not convert to json"  % {
+                        'entity': repr(obj.value)
+                    }
+                )
+
+        # return the value as stored on ProductAttributeValue in the correct type
         return obj.value
 
     class Meta:

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -13,6 +13,7 @@ ProductClass = get_model('catalogue', 'ProductClass')
 ProductCategory = get_model('catalogue', 'ProductCategory')
 ProductAttribute = get_model('catalogue', 'ProductAttribute')
 ProductAttributeValue = get_model('catalogue', 'ProductAttributeValue')
+AttributeOption = get_model('catalogue', 'AttributeOption')
 ProductImage = get_model('catalogue', 'ProductImage')
 Option = get_model('catalogue', 'Option')
 Partner = get_model('partner', 'Partner')
@@ -43,7 +44,19 @@ class ProductLinkSerializer(OscarHyperlinkedModelSerializer):
 
 class ProductAttributeValueSerializer(OscarModelSerializer):
     name = serializers.StringRelatedField(source="attribute")
-    value = serializers.StringRelatedField()
+    value = serializers.SerializerMethodField()
+
+    def get_value(self, obj):
+        obj_type = obj.attribute.type
+        if obj_type == ProductAttribute.OPTION:
+            return obj.value.option
+        elif obj_type == ProductAttribute.MULTI_OPTION:
+            return obj.value.values_list('option', flat=True)
+        elif obj_type == ProductAttribute.FILE:
+            return obj.value.url
+        elif obj_type == ProductAttribute.IMAGE:
+            return obj.value.url
+        return obj.value
 
     class Meta:
         model = ProductAttributeValue

--- a/oscarapi/tests/testproduct.py
+++ b/oscarapi/tests/testproduct.py
@@ -15,8 +15,8 @@ class ProductTest(APITest):
         "Check if we get a list of products with the default attributes"
         self.response = self.get('product-list')
         self.response.assertStatusEqual(200)
-        # we should have two products
-        self.assertEqual(len(self.response.body), 3)
+        # we should have four products
+        self.assertEqual(len(self.response.body), 4)
         # default we have 3 fields
         product = self.response.body[0]
         default_fields = ['id', 'url']
@@ -34,15 +34,23 @@ class ProductTest(APITest):
             self.assertIn(field, self.response.body)
         self.response.assertValueEqual('title', "Oscar T-shirt")
 
-    def test_product_attributes(self):
-        self.response = self.get(reverse('product-detail', args=(3,)))
+    def test_product_attribute_entity(self):
+        "Entity attribute tyoe should be supported by means of json method"
+        self.response = self.get(reverse('product-detail', args=(4,)))
         self.response.assertStatusEqual(200)
 
-        default_fields = ['stockrecords', 'description', 'title', 'url',
-                          'date_updated', 'recommended_products', 'attributes',
-                          'date_created', 'id', 'price', 'availability']
-        for field in default_fields:
-            self.assertIn(field, self.response.body)
+        self.response.assertValueEqual('title', "Entity product")
+
+        attributes = self.response.json()['attributes']
+        attributes_by_name = {a['name']:a['value'] for a in attributes}
+
+        self.assertIsInstance(attributes_by_name['entity'], string_types)
+        self.assertEqual(attributes_by_name['entity'], "<User: admin> has no json method, can not convert to json")
+
+    def test_product_attributes(self):
+        "All oscar attribute types should be supported except entity"
+        self.response = self.get(reverse('product-detail', args=(3,)))
+        self.response.assertStatusEqual(200)
 
         self.response.assertValueEqual('title', "lots of attributes")
 

--- a/setup.py
+++ b/setup.py
@@ -44,14 +44,13 @@ setup(
     # specify dependencies
     install_requires=[
         'setuptools',
-        'django-oscar>=1.2.2',
+        'django-oscar>=1.5.1',
         'djangorestframework>=3.3',
         'six'
     ],
     # mark test target to require extras.
     extras_require={
         'dev': ['django-nose', 'coverage', 'mock', 'twine'],
-        'docs': ['django-haystack<=2.7.0.dev0', 'sphinx', 'sphinx_rtd_theme'],
-        'django_1_11': ['django-haystack<=2.7.0.dev0']
+        'docs': ['sphinx', 'sphinx_rtd_theme'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'setuptools',
         'django-oscar>=1.5.1',
-        'djangorestframework>=3.3',
+        'djangorestframework>=3.4',
         'six'
     ],
     # mark test target to require extras.


### PR DESCRIPTION
These changes came from these commits:

- datetime: https://github.com/django-oscar/django-oscar/commit/b3875209d7ab8584b2e8e779b1f0ac0062dea940
- multioption: https://github.com/django-oscar/django-oscar/commit/246c38e8ecde95f2f22f7faa7696568effc0f790