### PR TITLE
Added the missing shipping method fields, that should all be availabl…

### DIFF
--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -93,7 +93,14 @@ class InlineBillingAddressSerializer(OscarModelSerializer):
 class ShippingMethodSerializer(serializers.Serializer):
     code = serializers.CharField(max_length=128)
     name = serializers.CharField(max_length=128)
+    description = serializers.CharField()
     price = serializers.SerializerMethodField('calculate_price')
+    is_discounted =  serializers.BooleanField()
+    discount = serializers.SerializerMethodField('calculate_discount')
+
+    def calculate_discount(self, obj):
+        basket = self.context.get('basket')
+        return obj.discount(basket)
 
     def calculate_price(self, obj):
         price = obj.calculate(self.context.get('basket'))

--- a/oscarapi/tests/testcheckout.py
+++ b/oscarapi/tests/testcheckout.py
@@ -479,6 +479,9 @@ class CheckOutTest(APITest):
         self.assertDictEqual(self.response[0], {
             'code': 'no-shipping-required',
             'name': 'No shipping required',
+            'description': "",
+            'is_discounted': False,
+            'discount': 0,
             'price': {
                 'currency': None,
                 'excl_tax': '0.00',
@@ -497,6 +500,9 @@ class CheckOutTest(APITest):
         self.assertDictEqual(self.response[0], {
             'code': 'free-shipping',
             'name': 'Free shipping',
+            'description': "",
+            'is_discounted': False,
+            'discount': 0,
             'price': {
                 'currency': 'EUR',
                 'excl_tax': '0.00',


### PR DESCRIPTION
…e according

to the spec of `oscar.apps.shipping.method.Base`