### PR TITLE
Fix ApiGatewayMiddleWare in Python3

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -11,6 +11,7 @@ from django.utils.translation import ugettext as _
 
 from oscar.core.loading import get_class
 
+from rest_framework import HTTP_HEADER_ENCODING
 from rest_framework import exceptions
 from rest_framework import authentication
 
@@ -175,6 +176,7 @@ class ApiGatewayMiddleWare(MiddlewareMixin, IsApiRequest):
     def process_request(self, request):
         if self.is_api_request(request):
             key = authentication.get_authorization_header(request)
+            key = key.decode(HTTP_HEADER_ENCODING)
             if models.ApiKey.objects.filter(key=key).exists():
                 return None
 

--- a/oscarapi/tests/test_middleware.py
+++ b/oscarapi/tests/test_middleware.py
@@ -1,0 +1,38 @@
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse
+from django.test import RequestFactory, TestCase
+
+from oscarapi.middleware import ApiGatewayMiddleWare
+from oscarapi.models import ApiKey
+
+
+class ApiGatewayMiddleWareTest(TestCase):
+
+    rf = RequestFactory()
+
+    def setUp(self):
+        super(ApiGatewayMiddleWareTest, self).setUp()
+
+        ApiKey.objects.create(key='testapikey')
+
+    def tearDown(self):
+        ApiKey.objects.filter(key='testapikey').delete()
+
+        super(ApiGatewayMiddleWareTest, self).tearDown()
+
+    def test_process_request(self):
+        basket_url = reverse('api-basket')
+
+        # without Authorization header
+        request = self.rf.get(basket_url)
+        with self.assertRaises(PermissionDenied):
+            ApiGatewayMiddleWare().process_request(request)
+
+        # invalid Authorization header
+        request = self.rf.get(basket_url, HTTP_AUTHORIZATION='wrongkey')
+        with self.assertRaises(PermissionDenied):
+            ApiGatewayMiddleWare().process_request(request)
+
+        # valid Authorization header
+        request = self.rf.get(basket_url, HTTP_AUTHORIZATION='testapikey')
+        self.assertIsNone(ApiGatewayMiddleWare().process_request(request))


### PR DESCRIPTION
`authentication.get_authorization_header` returns bytestring and in Python3 `'foo'` and `b'foo'` are not same.
For that reason `models.ApiKey.objects.filter(key=key).exists()` returns False.