### PR TITLE
Changed exception for invalid session ids, add test for the correct response.

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -84,7 +84,7 @@ class HeaderSessionMiddleware(SessionMiddleware, IsApiRequest):
                 if parsed_session_uri is not None:
                     domain = get_domain(request)
                     if parsed_session_uri['realm'] != domain:
-                        raise exceptions.NotAcceptable(
+                        raise exceptions.PermissionDenied(
                             _('Can not accept cookie with realm %s on realm %s') % (
                                 parsed_session_uri['realm'],
                                 domain


### PR DESCRIPTION
Fix for #139 

Unsure why the exception is explicitly converted to a HTTP response (the other middlewares simply raise the error), but the test checks for the correct result.