### PR TITLE
Improve consistency in serializers

### DIFF
--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -140,7 +140,7 @@ class OrderLineSerializer(OscarHyperlinkedModelSerializer):
 
     class Meta:
         model = OrderLine
-        fields = overridable('OSCAR_ORDERLINE_FIELD', default=(
+        fields = overridable('OSCARAPI_ORDERLINE_FIELDS', default=(
             'attributes', 'url', 'product', 'stockrecord', 'quantity',
             'price_currency', 'price_excl_tax', 'price_incl_tax',
             'price_incl_tax_excl_discounts', 'price_excl_tax_excl_discounts',
@@ -195,7 +195,7 @@ class OrderSerializer(OscarHyperlinkedModelSerializer):
 
     class Meta:
         model = Order
-        fields = overridable('OSCARAPI_ORDER_FIELD', default=(
+        fields = overridable('OSCARAPI_ORDER_FIELDS', default=(
             'number', 'basket', 'url', 'lines',
             'owner', 'billing_address', 'currency', 'total_incl_tax',
             'total_excl_tax', 'shipping_incl_tax', 'shipping_excl_tax',

--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -1,7 +1,6 @@
 import warnings
 
 from django.db import IntegrityError
-from rest_framework.response import Response
 
 from django.conf import settings
 from django.urls import reverse, NoReverseMatch
@@ -141,11 +140,11 @@ class OrderLineSerializer(OscarHyperlinkedModelSerializer):
 
     class Meta:
         model = OrderLine
-        fields = overridable('OSCAR_ORDERLINE_FIELD', default=[
+        fields = overridable('OSCAR_ORDERLINE_FIELD', default=(
             'attributes', 'url', 'product', 'stockrecord', 'quantity',
             'price_currency', 'price_excl_tax', 'price_incl_tax',
             'price_incl_tax_excl_discounts', 'price_excl_tax_excl_discounts',
-            'order'])
+            'order'))
 
 
 class OrderOfferDiscountSerializer(OfferDiscountSerializer):
@@ -363,7 +362,7 @@ class UserAddressSerializer(OscarModelSerializer):
 
     class Meta:
         model = UserAddress
-        fields = overridable('OSCARAPI_USERADDRESS_FIELDS', (
+        fields = overridable('OSCARAPI_USERADDRESS_FIELDS', default=(
             'id', 'title', 'first_name', 'last_name', 'line1', 'line2',
             'line3', 'line4', 'state', 'postcode', 'search_text',
             'phone_number', 'notes', 'is_default_for_shipping',

--- a/oscarapi/serializers/login.py
+++ b/oscarapi/serializers/login.py
@@ -16,7 +16,7 @@ def field_length(fieldname):
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = overridable('OSCARAPI_USER_FIELDS', (
+        fields = overridable('OSCARAPI_USER_FIELDS', default=(
             User.USERNAME_FIELD, 'id', 'date_joined',))
 
 


### PR DESCRIPTION
The main change here is changing the type of default fields for `OrderLineSerializer` from `list` to `tuple`. This is not critical, but sometimes in projects, I need to override some serializers and add additional fields.
E.g.
```python
class UpdatedOrderSerializer(OrderSerializer):
    additional_field = ...

    class Meta(OrderSerializer.Meta):
    fields = OrderSerializer.Meta.fields + ('additional_field',)
```
Only for `OrderLineSerializer` I need to use `list`.
```python
    fields = OrderLineSerializer.Meta.fields + ['additional_field']
```
And this looks a bit inconsistent.