### PR TITLE
Add skipped and refactor existing checkout tests

### DIFF
--- a/oscarapi/tests/utils.py
+++ b/oscarapi/tests/utils.py
@@ -127,10 +127,10 @@ class APITest(TestCase):
 
     @response.setter
     def response(self, response):
-        self._response = ParsedReponse(response, self)
+        self._response = ParsedResponse(response, self)
 
 
-class ParsedReponse(object):
+class ParsedResponse(object):
     def __init__(self, response, unittestcase):
         self.response = response
         self.t = unittestcase


### PR DESCRIPTION
There were 3 skipped tests:

1. `test_checkout_header`
2. `test_cart_immutable_after_checkout`
3. `test_client_can_not_falsify_picing`

3rd test `test_client_can_not_falsify_picing` renamed to `test_client_cannot_falsify_shipping_charge` (since we already have test for total price `test_checkout_total_error`). Because of this `test_checkout_total_error` renamed to `test_client_cannot_falsify_total_price`.

All other tests here were refactored to improve readability.

Refs: #171 