### PR TITLE
Fix quantity validation in AddProductView

### DIFF
--- a/oscarapi/tests/unit/testbasket.py
+++ b/oscarapi/tests/unit/testbasket.py
@@ -1070,12 +1070,18 @@ class BasketTest(APITest):
             self.response.assertStatusEqual(406)
 
         with self.subTest("Sequential requests"):
-            for _ in range(2):
-                self.response = self.post(
-                    "api-basket-add-product",
-                    url="http://testserver/api/products/1/",
-                    quantity=20,
-                )
+            self.response = self.post(
+                "api-basket-add-product",
+                url="http://testserver/api/products/1/",
+                quantity=20,
+            )
+            self.response.assertStatusEqual(200)
+
+            self.response = self.post(
+                "api-basket-add-product",
+                url="http://testserver/api/products/1/",
+                quantity=20,
+            )
             self.response.assertStatusEqual(406)
 
     def test_adjust_basket_line_quantity(self):

--- a/oscarapi/tests/unit/testbasket.py
+++ b/oscarapi/tests/unit/testbasket.py
@@ -1061,12 +1061,22 @@ class BasketTest(APITest):
         """Test if an anonymous user cannot add more products to his
             basket when stock is not sufficient
         """
-        self.response = self.post(
-            "api-basket-add-product",
-            url="http://testserver/api/products/1/",
-            quantity=25,
-        )
-        self.response.assertStatusEqual(406)
+        with self.subTest("Single request"):
+            self.response = self.post(
+                "api-basket-add-product",
+                url="http://testserver/api/products/1/",
+                quantity=25,
+            )
+            self.response.assertStatusEqual(406)
+
+        with self.subTest("Sequential requests"):
+            for _ in range(2):
+                self.response = self.post(
+                    "api-basket-add-product",
+                    url="http://testserver/api/products/1/",
+                    quantity=20,
+                )
+            self.response.assertStatusEqual(406)
 
     def test_adjust_basket_line_quantity(self):
         """Test if we can update the quantity of a line"""

--- a/oscarapi/views/basket.py
+++ b/oscarapi/views/basket.py
@@ -96,13 +96,16 @@ class AddProductView(APIView):
         if not availability.is_available_to_buy:
             return False, availability.message
 
+        current_qty = basket.product_quantity(product)
+        desired_qty = current_qty + quantity
+
         # check if we can buy this quantity
-        allowed, message = availability.is_purchase_permitted(quantity)
+        allowed, message = availability.is_purchase_permitted(desired_qty)
         if not allowed:
             return False, message
 
         # check if there is a limit on amount
-        allowed, message = basket.is_quantity_allowed(quantity)
+        allowed, message = basket.is_quantity_allowed(desired_qty)
         if not allowed:
             return False, message
         return True, None


### PR DESCRIPTION
The current implementation doesn't account for previously added lines of the same product.