### PR TITLE
Defer downloading of images until the file data is accessed.

### DIFF
--- a/docs/source/usage/the_admin_api.rst
+++ b/docs/source/usage/the_admin_api.rst
@@ -22,4 +22,72 @@ The *Admin API* is also accessible in the browsable API when your logged in user
 .. image:: ../images/admin-api.png
    :alt: The Admin API
 
+Example add an image
+--------------------
 
+To add an image to an exiting product and change nothing else, it is best to use
+the ``PATCH`` http method. This will let you send incomplete information to
+the api, and update only what is being sent.
+
+The are 2 methods to update and existing product, depending on whether you
+know the current api url or you only know the product ``upc``.
+
+Suppose we know the full url then it can be done like this::
+
+    session.post(
+        "http://127.0.0.1:8000/oscarapi/admin/products/1/",
+        json={
+            "images": [{
+                "original": "http://permanentmarkers.nl/images/logo.png",
+                "caption": "hai",
+                "display_order": 0
+            }]
+        }
+    )
+
+The api will download the image from that url and add it to the list.
+
+Suppose you don't know the url in the api, you'd have to know some unique attribute,
+for example the upc. You can just use the product list api and if you send
+enough data to uniquely identify the product, it will succeed::
+
+    session.post(
+        "http://127.0.0.1:8000/oscarapi/admin/products/",
+        json={
+            "upc": "1_5_1",
+            "images": [{
+                "original": "http://permanentmarkers.nl/images/logo.png",
+                "caption": "hai",
+                "display_order": 0
+            }]
+        }
+    )
+
+That will also work, you can even try to paste the bodies into the browsable
+html api and it will update your product and add the image. The second method
+makes the api very suitable for integration with external parties, you can just
+send updates and forget about it, no need to search for the product first or
+whatever.
+
+An optimization
+---------------
+
+Suppose you want to integrate with an external system and want to send you data
+in a fire and forget way. If you have a lot of images, the api will need to
+download the images every time, to check if they are know images or new images
+to determine if there is anything to update. That is a lot of useless traffic.
+
+To remedy that, you can send the sha1 hash of the image along with it as a get
+parameter. oscarapi will not even try to download it if the image is known::
+
+    session.post(
+        "http://127.0.0.1:8000/oscarapi/admin/products/",
+        json={
+            "upc": "1_5_1",
+            "images": [{
+                "original": "http://permanentmarkers.nl/images/logo.png?sha1=751499a82438277cb3cfb5db268bd41696739b3b",
+                "caption": "hai",
+                "display_order": 0
+            }]
+        }
+    )

--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -2,15 +2,14 @@ import logging
 import operator
 
 from os.path import basename, join
-from io import BytesIO
-from urllib.parse import urlsplit
-from urllib.request import urlopen
-
+from urllib.parse import urlsplit, parse_qs
+from urllib.request import urlretrieve
 from django.conf import settings
 from django.db import IntegrityError
 from django.utils.translation import ugettext as _
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
+from django.utils.functional import cached_property
 
 from rest_framework import serializers, relations
 from rest_framework.fields import get_attribute
@@ -272,6 +271,53 @@ class SingleValueSlugRelatedField(serializers.SlugRelatedField):
         return {self.slug_field: data}
 
 
+class LazyRemoteFile(File):
+    """
+    This file will defer downloading untill the file data is accessed.
+
+    It will also try to parsed a sha1 hash from the url, and store it as an
+    attribute, so the file_hash function will use it. You can use this feature
+    to avoid unnescessary downloading of files. Just compute the hash on the
+    client side and send it along in the url like this::
+
+        http://example.com/image.jpg?sha1=751499a82438277cb3cfb5db268bd41696739b3b
+
+    It will only download if not allready available locally.
+    """
+
+    def __init__(self, url, name=None, mode="rb"):
+        parsed_url = urlsplit(url)
+        self.mode = mode
+        self.name = name
+        self.size = 1
+        self.url = url
+
+        # compute a hash if available
+        sha1_hash = next(iter(parse_qs(parsed_url.query).get("sha1", [])), None)
+        if sha1_hash:
+            self.sha1 = sha1_hash
+
+    def read(self, size=-1):
+        return self.file.read(size)
+
+    @cached_property
+    def file(self):
+        local_filename, _ = urlretrieve(self.url, self.name)
+        return open(local_filename, self.mode)
+
+    def __str__(self):
+        return self.url or ""
+
+    def __bool__(self):
+        return bool(self.url)
+
+    def open(self, mode="rb"):
+        if not self.closed:
+            self.seek(0)
+
+        return self
+
+
 class ImageUrlField(serializers.ImageField):
     def __init__(self, **kwargs):
         super(ImageUrlField, self).__init__(**kwargs)
@@ -287,10 +333,8 @@ class ImageUrlField(serializers.ImageField):
                 if (
                     host != parsed_url.netloc
                 ):  # we are only downloading files from a foreign server
-                    # it is a foreign image, download it
-                    response = urlopen(data)
-                    image_file_like = BytesIO(response.read())
-                    file_object = File(image_file_like, name=basename(parsed_url.path))
+                    # download only when needed
+                    return LazyRemoteFile(data, name=basename(parsed_url.path))
                 else:
                     location = parsed_url.path
                     path = join(

--- a/oscarapi/utils/files.py
+++ b/oscarapi/utils/files.py
@@ -10,6 +10,10 @@ def file_hash(content):
     >>> file_hash(BytesIO(long_text.encode()))
     'cf3c7be4778cded29fab4b66622c5e8af91d01a9'
     """
+    sha1 = getattr(content, "sha1", None)
+    if sha1 is not None:
+        return sha1
+
     hasher = hashlib.sha1()
     buf = content.read(65536)
     while len(buf) > 0:


### PR DESCRIPTION
Also try to parsed a sha1 hash from the url, and store it as an
attribute, so the file_hash function will use it. You can use this feature
to avoid unnescessary downloading of files. Just compute the hash on the
client side and send it along in the url like this::

    http://example.com/image.jpg?sha1=751499a82438277cb3cfb5db268bd41696739b3b

It will only download if not allready available locally.