### PR TITLE
 Added error message when construct_id_filter does not construct a useful filter.

### DIFF
--- a/oscarapi/tests/unit/testproduct.py
+++ b/oscarapi/tests/unit/testproduct.py
@@ -1386,6 +1386,22 @@ class TestProductAdmin(APITest):
         self.response = self.post("admin-product-list", **data)
         self.response.assertStatusEqual(201)
 
+    def test_patch_product(self):
+        self.login("admin", "admin")
+        self.response = self.put(
+            "admin-product-list",
+            **{"upc": 1234, "product_class": "t-shirt", "slug": "oscar-t-shirt-henk"}
+        )
+        self.response.assertStatusEqual(200)
+
+    def test_put_product_ambiguous(self):
+        self.login("admin", "admin")
+        self.response = self.put(
+            "admin-product-list",
+            **{"product_class": "t-shirt", "slug": "oscar-t-shirt-henk"}
+        )
+        self.response.assertStatusEqual(404)
+
     def test_put_child(self):
         self.login("admin", "admin")
         url = reverse("admin-product-detail", args=(2,))

--- a/oscarapi/views/admin/product.py
+++ b/oscarapi/views/admin/product.py
@@ -60,9 +60,14 @@ class ProductAdminList(generics.UpdateAPIView, generics.ListCreateAPIView):
         """
         try:
             automatic_filter = construct_id_filter(Product, self.request.data)
-            obj = Product.objects.get(automatic_filter)
-            self.check_object_permissions(self.request, obj)
-            return obj
+            if automatic_filter:
+                obj = Product.objects.get(automatic_filter)
+                self.check_object_permissions(self.request, obj)
+                return obj
+            else:
+                raise NotFound(
+                    "Not enough info to identify %s." % Product._meta.object_name
+                )
         except Product.DoesNotExist:
             raise Http404("No %s matches the given query." % Product._meta.object_name)
 


### PR DESCRIPTION
This is a very annoying bug. If you are not sending enough info to the api to be able to infer which object is meant, a MultipleObjectsReturned error occurs. This fixes that so it will show a proper error message.