### PR TITLE
Accept *args and **kwargs so DRF versioning will work as expected

### DIFF
--- a/oscarapi/views/basket.py
+++ b/oscarapi/views/basket.py
@@ -59,7 +59,9 @@ class BasketView(APIView):
 
     serializer_class = BasketSerializer
 
-    def get(self, request, format=None):  # pylint: disable=redefined-builtin
+    def get(
+        self, request, format=None, *args, **kwargs
+    ):  # pylint: disable=redefined-builtin
         basket = operations.get_basket(request)
         ser = self.serializer_class(basket, context={"request": request})
         return Response(ser.data)
@@ -113,7 +115,9 @@ class AddProductView(APIView):
             return False, message
         return True, None
 
-    def post(self, request, format=None):  # pylint: disable=redefined-builtin
+    def post(
+        self, request, format=None, *args, **kwargs
+    ):  # pylint: disable=redefined-builtin
         p_ser = self.add_product_serializer_class(
             data=request.data, context={"request": request}
         )
@@ -158,7 +162,9 @@ class AddVoucherView(APIView):
     add_voucher_serializer_class = VoucherAddSerializer
     serializer_class = VoucherSerializer
 
-    def post(self, request, format=None):  # pylint: disable=redefined-builtin
+    def post(
+        self, request, format=None, *args, **kwargs
+    ):  # pylint: disable=redefined-builtin
         v_ser = self.add_voucher_serializer_class(
             data=request.data, context={"request": request}
         )
@@ -238,7 +244,9 @@ class ShippingMethodView(APIView):
         )
         return Response(ser.data)
 
-    def get(self, request, format=None):  # pylint: disable=redefined-builtin
+    def get(
+        self, request, format=None, *args, **kwargs
+    ):  # pylint: disable=redefined-builtin
         """
         Get the available shipping methods and their cost for this order.
 
@@ -247,7 +255,9 @@ class ShippingMethodView(APIView):
         """
         return self._get(request, format=format)
 
-    def post(self, request, format=None):  # pylint: disable=redefined-builtin
+    def post(
+        self, request, format=None, *args, **kwargs
+    ):  # pylint: disable=redefined-builtin
         s_ser = self.serializer_class(data=request.data, context={"request": request})
         if s_ser.is_valid():
             shipping_address = ShippingAddress(**s_ser.validated_data)
@@ -295,7 +305,7 @@ class LineList(BasketPermissionMixin, generics.ListCreateAPIView):
         return prepped_basket.all_lines()
 
     def post(
-        self, request, pk, format=None
+        self, request, pk, format=None, *args, **kwargs
     ):  # pylint: disable=redefined-builtin,arguments-differ
         data_basket = self.get_data_basket(request.data, format)
         self.check_basket_permission(request, basket=data_basket)

--- a/oscarapi/views/basket.py
+++ b/oscarapi/views/basket.py
@@ -59,9 +59,7 @@ class BasketView(APIView):
 
     serializer_class = BasketSerializer
 
-    def get(
-        self, request, format=None, *args, **kwargs
-    ):  # pylint: disable=redefined-builtin
+    def get(self, request, *args, **kwargs):  # pylint: disable=redefined-builtin
         basket = operations.get_basket(request)
         ser = self.serializer_class(basket, context={"request": request})
         return Response(ser.data)
@@ -115,9 +113,7 @@ class AddProductView(APIView):
             return False, message
         return True, None
 
-    def post(
-        self, request, format=None, *args, **kwargs
-    ):  # pylint: disable=redefined-builtin
+    def post(self, request, *args, **kwargs):  # pylint: disable=redefined-builtin
         p_ser = self.add_product_serializer_class(
             data=request.data, context={"request": request}
         )
@@ -162,9 +158,7 @@ class AddVoucherView(APIView):
     add_voucher_serializer_class = VoucherAddSerializer
     serializer_class = VoucherSerializer
 
-    def post(
-        self, request, format=None, *args, **kwargs
-    ):  # pylint: disable=redefined-builtin
+    def post(self, request, *args, **kwargs):  # pylint: disable=redefined-builtin
         v_ser = self.add_voucher_serializer_class(
             data=request.data, context={"request": request}
         )
@@ -229,9 +223,7 @@ class ShippingMethodView(APIView):
     serializer_class = ShippingAddressSerializer
     shipping_method_serializer_class = ShippingMethodSerializer
 
-    def _get(
-        self, request, shipping_address=None, format=None
-    ):  # pylint: disable=redefined-builtin
+    def _get(self, request, shipping_address=None):  # pylint: disable=redefined-builtin
         basket = operations.get_basket(request)
         shiping_methods = Repository().get_shipping_methods(
             basket=basket,
@@ -244,24 +236,20 @@ class ShippingMethodView(APIView):
         )
         return Response(ser.data)
 
-    def get(
-        self, request, format=None, *args, **kwargs
-    ):  # pylint: disable=redefined-builtin
+    def get(self, request, *args, **kwargs):  # pylint: disable=redefined-builtin
         """
         Get the available shipping methods and their cost for this order.
 
         GET:
         A list of shipping method details and the prices.
         """
-        return self._get(request, format=format)
+        return self._get(request)
 
-    def post(
-        self, request, format=None, *args, **kwargs
-    ):  # pylint: disable=redefined-builtin
+    def post(self, request, *args, **kwargs):  # pylint: disable=redefined-builtin
         s_ser = self.serializer_class(data=request.data, context={"request": request})
         if s_ser.is_valid():
             shipping_address = ShippingAddress(**s_ser.validated_data)
-            return self._get(request, format=format, shipping_address=shipping_address)
+            return self._get(request, shipping_address=shipping_address)
 
         return Response(s_ser.errors, status=status.HTTP_406_NOT_ACCEPTABLE)
 

--- a/oscarapi/views/checkout.py
+++ b/oscarapi/views/checkout.py
@@ -130,7 +130,7 @@ class CheckoutView(views.APIView):
     order_serializer_class = OrderSerializer
     serializer_class = CheckoutSerializer
 
-    def post(self, request, format=None):
+    def post(self, request, format=None, *args, **kwargs):
         # TODO: Make it possible to create orders with options.
         # at the moment, no options are passed to this method, which means they
         # are also not created.

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -49,7 +49,7 @@ class LoginView(APIView):
 
     serializer_class = LoginSerializer
 
-    def get(self, request, format=None, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         if settings.DEBUG:
             if request.user.is_authenticated:
                 ser = UserSerializer(request.user, many=False)
@@ -62,7 +62,7 @@ class LoginView(APIView):
         "Hook to enforce rules when merging baskets."
         basket.merge(anonymous_basket)
 
-    def post(self, request, format=None, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         ser = self.serializer_class(data=request.data)
         if ser.is_valid():
 
@@ -93,7 +93,7 @@ class LoginView(APIView):
 
         return Response(ser.errors, status=status.HTTP_401_UNAUTHORIZED)
 
-    def delete(self, request, format=None):
+    def delete(self, request, *args, **kwargs):
         """
         Destroy the session.
 

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -49,7 +49,7 @@ class LoginView(APIView):
 
     serializer_class = LoginSerializer
 
-    def get(self, request, format=None):
+    def get(self, request, format=None, *args, **kwargs):
         if settings.DEBUG:
             if request.user.is_authenticated:
                 ser = UserSerializer(request.user, many=False)
@@ -62,7 +62,7 @@ class LoginView(APIView):
         "Hook to enforce rules when merging baskets."
         basket.merge(anonymous_basket)
 
-    def post(self, request, format=None):
+    def post(self, request, format=None, *args, **kwargs):
         ser = self.serializer_class(data=request.data)
         if ser.is_valid():
 

--- a/oscarapi/views/product.py
+++ b/oscarapi/views/product.py
@@ -68,7 +68,7 @@ class ProductPrice(generics.RetrieveAPIView):
     serializer_class = PriceSerializer
 
     def get(
-        self, request, pk=None, format=None
+        self, request, pk=None, format=None, *args, **kwargs
     ):  # pylint: disable=redefined-builtin,arguments-differ
         product = self.get_object()
         strategy = Selector().strategy(request=request, user=request.user)

--- a/oscarapi/views/product.py
+++ b/oscarapi/views/product.py
@@ -68,7 +68,7 @@ class ProductPrice(generics.RetrieveAPIView):
     serializer_class = PriceSerializer
 
     def get(
-        self, request, pk=None, format=None, *args, **kwargs
+        self, request, pk=None, *args, **kwargs
     ):  # pylint: disable=redefined-builtin,arguments-differ
         product = self.get_object()
         strategy = Selector().strategy(request=request, user=request.user)
@@ -97,7 +97,7 @@ class ProductAvailability(generics.RetrieveAPIView):
     serializer_class = AvailabilitySerializer
 
     def get(
-        self, request, pk=None, format=None
+        self, request, pk=None, *args, **kwargs
     ):  # pylint: disable=redefined-builtin,arguments-differ
         product = self.get_object()
         strategy = Selector().strategy(request=request, user=request.user)

--- a/oscarapi/views/root.py
+++ b/oscarapi/views/root.py
@@ -43,7 +43,9 @@ def ADMIN_APIS(r, f):
 
 
 @api_view(("GET",))
-def api_root(request, format=None):  # pylint: disable=redefined-builtin
+def api_root(
+    request, format=None, *args, **kwargs
+):  # pylint: disable=redefined-builtin
     """
     GET:
     Display all available urls.


### PR DESCRIPTION
When you want to use [URLPathVersioning](https://www.django-rest-framework.org/api-guide/versioning/#urlpathversioning), all API views will receive an extra `version` keyword parameter.

The default API Views of REST Framework do accept this with `**kwargs` so I added this to the views in OscarAPI as well. The tests all pass, so there is not a backward compatibility issue.

 I'll update the release notes mentioning that users should modify their oscarapi overrides to accept the `*args` and `**kwargs` arguments.