### PR TITLE
Mount the admin api on the /admin endpoint with path()

### DIFF
--- a/oscarapi/tests/unit/testadminapi.py
+++ b/oscarapi/tests/unit/testadminapi.py
@@ -3,7 +3,7 @@ import sys
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
-from django.urls import reverse
+from django.urls import reverse, URLResolver
 
 from oscarapi import urls
 from oscarapi.tests.utils import APITest
@@ -46,17 +46,20 @@ class BlockAdminApiTest(APITest):
         "The admin api urls should not be registered when OSCARAPI_BLOCK_ADMIN_API_ACCESS is True"
         with self.settings(OSCARAPI_BLOCK_ADMIN_API_ACCESS=False):
             self.reload_modules([urls, sys.modules[settings.ROOT_URLCONF]])
-            urlpattern_names = [url.name for url in urls.urlpatterns]
+            # we assume here that the last mountpoint is the admin api url resolver
+            url_entry = urls.urlpatterns[-1]
+            self.assertIsInstance(url_entry, URLResolver)
+
+            urlpattern_names = [url.name for url in url_entry.url_patterns]
 
             for pattern in urls.admin_urlpatterns:
                 self.assertIn(pattern.name, urlpattern_names)
 
         with self.settings(OSCARAPI_BLOCK_ADMIN_API_ACCESS=True):
             self.reload_modules([urls, sys.modules[settings.ROOT_URLCONF]])
-            urlpattern_names = [url.name for url in urls.urlpatterns]
-
-            for pattern in urls.admin_urlpatterns:
-                self.assertNotIn(pattern.name, urlpattern_names)
+            # we assume here that the last mountpoint is the admin api url resolver
+            url_entry = urls.urlpatterns[-1]
+            self.assertNotIsInstance(url_entry, URLResolver)
 
     def test_api_admin_permission(self):
         permission = APIAdminPermission()

--- a/oscarapi/urls.py
+++ b/oscarapi/urls.py
@@ -1,6 +1,6 @@
 # pylint: disable=unbalanced-tuple-unpacking
 from django.conf import settings
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from oscarapi.utils.loading import get_api_classes, get_api_class
@@ -228,83 +228,79 @@ urlpatterns = [
 ]
 
 admin_urlpatterns = [
-    path("admin/products/", ProductAdminList.as_view(), name="admin-product-list"),
+    path("products/", ProductAdminList.as_view(), name="admin-product-list"),
     path(
-        "admin/products/<int:pk>/",
-        ProductAdminDetail.as_view(),
-        name="admin-product-detail",
+        "products/<int:pk>/", ProductAdminDetail.as_view(), name="admin-product-detail",
     ),
     path(
-        "admin/productclasses/",
+        "productclasses/",
         ProductClassAdminList.as_view(),
         name="admin-productclass-list",
     ),
     path(
-        "admin/productclasses/<slug:slug>/",
+        "productclasses/<slug:slug>/",
         ProductClassAdminDetail.as_view(),
         name="admin-productclass-detail",
     ),
-    path("admin/categories/", CategoryAdminList.as_view(), name="admin-category-list"),
+    path("categories/", CategoryAdminList.as_view(), name="admin-category-list"),
     path(
-        "admin/categories/<int:pk>/",
+        "categories/<int:pk>/",
         CategoryAdminDetail.as_view(),
         name="admin-category-detail",
     ),
     re_path(
-        r"^admin/categories/(?P<breadcrumbs>.*)/$",
+        r"^categories/(?P<breadcrumbs>.*)/$",
         CategoryAdminList.as_view(),
         name="admin-category-child-list",
     ),
     path(
-        "admin/productattributes/",
+        "productattributes/",
         ProductAttributeAdminList.as_view(),
         name="admin-productattribute-list",
     ),
     path(
-        "admin/stockrecords/<int:pk>/",
+        "stockrecords/<int:pk>/",
         StockRecordDetail.as_view(),
         name="admin-stockrecord-detail",
     ),
-    path("admin/partners/", PartnerList.as_view(), name="partner-list"),
-    path("admin/partners/<int:pk>/", PartnerDetail.as_view(), name="partner-detail"),
+    path("partners/", PartnerList.as_view(), name="partner-list"),
+    path("partners/<int:pk>/", PartnerDetail.as_view(), name="partner-detail"),
     path(
-        "admin/productattributes/<int:pk>/",
+        "productattributes/<int:pk>/",
         ProductAttributeAdminDetail.as_view(),
         name="admin-productattribute-detail",
     ),
     path(
-        "admin/attributeoptiongroups/",
+        "attributeoptiongroups/",
         AttributeOptionGroupAdminList.as_view(),
         name="admin-attributeoptiongroup-list",
     ),
     path(
-        "admin/attributeoptiongroups/<int:pk>/",
+        "attributeoptiongroups/<int:pk>/",
         AttributeOptionGroupAdminDetail.as_view(),
         name="admin-attributeoptiongroup-detail",
     ),
-    path("admin/orders/", OrderAdminList.as_view(), name="admin-order-list"),
+    path("orders/", OrderAdminList.as_view(), name="admin-order-list"),
+    path("orders/<int:pk>/", OrderAdminDetail.as_view(), name="admin-order-detail"),
     path(
-        "admin/orders/<int:pk>/", OrderAdminDetail.as_view(), name="admin-order-detail"
-    ),
-    path(
-        "admin/orders/<int:pk>/lines/",
+        "orders/<int:pk>/lines/",
         OrderLineAdminList.as_view(),
         name="admin-order-lines-list",
     ),
     path(
-        "admin/orderlines/<int:pk>/",
+        "orderlines/<int:pk>/",
         OrderLineAdminDetail.as_view(),
         name="admin-order-lines-detail",
     ),
     path(
-        "admin/orderlineattributes/<int:pk>/",
+        "orderlineattributes/<int:pk>/",
         OrderLineAttributeAdminDetail.as_view(),
         name="admin-order-lineattributes-detail",
     ),
-    path("admin/users/", UserList.as_view(), name="user-list"),
+    path("users/", UserList.as_view(), name="user-list"),
 ]
 
 if not getattr(settings, "OSCARAPI_BLOCK_ADMIN_API_ACCESS", True):
-    urlpatterns = urlpatterns + admin_urlpatterns
+    urlpatterns.append(path("admin/", include(admin_urlpatterns)))
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
So it's easier to customize when you would like to change / adapt the mountpoint, add url's to it, mount it with a different name etc.