### PR TITLE
Change guest email to email property

### DIFF
--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -171,6 +171,8 @@ class OrderSerializer(OscarHyperlinkedModelSerializer):
     billing_address = InlineBillingAddressSerializer(
         many=False, required=False)
 
+    email = serializers.CharField()
+
     payment_url = serializers.SerializerMethodField()
     offer_discounts = serializers.SerializerMethodField()
     voucher_discounts = serializers.SerializerMethodField()
@@ -200,7 +202,7 @@ class OrderSerializer(OscarHyperlinkedModelSerializer):
             'owner', 'billing_address', 'currency', 'total_incl_tax',
             'total_excl_tax', 'shipping_incl_tax', 'shipping_excl_tax',
             'shipping_address', 'shipping_method', 'shipping_code', 'status',
-            'guest_email', 'date_placed', 'payment_url', 'offer_discounts',
+            'email', 'date_placed', 'payment_url', 'offer_discounts',
             'voucher_discounts')
         )
 

--- a/oscarapi/tests/unit/testcheckout.py
+++ b/oscarapi/tests/unit/testcheckout.py
@@ -22,7 +22,7 @@ class CheckOutTest(APITest):
     def _get_common_payload(self, basket_url):
         return {
             "basket": basket_url,
-            "guest_email": "henk@example.com",
+            "email": "henk@example.com",
             "total": "50.00",
             "shipping_method_code": "no-shipping-required",
             "shipping_charge": {
@@ -61,8 +61,7 @@ class CheckOutTest(APITest):
         response = self.post('api-checkout', **payload)
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(
-            response.data['guest_email'], '',
-            'Guest email should be blank since user was authenticated'
+            response.data['email'], 'nobody@nobody.niks',
         )
         self.assertEqual(
             Basket.objects.get(pk=basket['id']).status, 'Frozen',
@@ -87,8 +86,7 @@ class CheckOutTest(APITest):
         response = self.post('api-checkout', session_id='nobody', authenticated=True, **payload)
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(
-            response.data['guest_email'], '',
-            'Guest email should be blank since user was authenticated'
+            response.data['email'], 'nobody@nobody.niks',
         )
         self.assertEqual(
             Basket.objects.get(pk=basket['id']).status, 'Frozen',
@@ -261,7 +259,6 @@ class CheckOutTest(APITest):
         basket = response.data
 
         payload = self._get_common_payload(basket['url'])
-        del payload['guest_email']
 
         with self.settings(OSCAR_ALLOW_ANON_CHECKOUT=True):
             response = self.post('api-checkout', **payload)
@@ -282,7 +279,7 @@ class CheckOutTest(APITest):
             payload['guest_email'] = 'henk@example.com'
             response = self.post('api-checkout', **payload)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data['guest_email'], 'henk@example.com')
+            self.assertEqual(response.data['email'], 'henk@example.com')
             self.assertEqual(
                 Basket.objects.get(pk=basket['id']).status, 'Frozen',
                 'Basket should be frozen after placing order and before payment'


### PR DESCRIPTION
When no user is attached to the order the email property will be the order.guest_email.
When a user is attached to the order the email property will be the order.user.email
A this moment there is no way of getting the order email via the api because the user serializer doesn't have a email field