### PR TITLE
Replace guest email with email property on order API

### DIFF
--- a/oscarapi/serializers/checkout.py
+++ b/oscarapi/serializers/checkout.py
@@ -187,6 +187,8 @@ class OrderSerializer(OscarHyperlinkedModelSerializer):
     shipping_address = InlineShippingAddressSerializer(many=False, required=False)
     billing_address = InlineBillingAddressSerializer(many=False, required=False)
 
+    email = serializers.EmailField(read_only=True)
+
     payment_url = serializers.SerializerMethodField()
     offer_discounts = serializers.SerializerMethodField()
     voucher_discounts = serializers.SerializerMethodField()
@@ -231,7 +233,7 @@ class OrderSerializer(OscarHyperlinkedModelSerializer):
                 "shipping_method",
                 "shipping_code",
                 "status",
-                "guest_email",
+                "email",
                 "date_placed",
                 "payment_url",
                 "offer_discounts",

--- a/oscarapi/tests/unit/testcheckout.py
+++ b/oscarapi/tests/unit/testcheckout.py
@@ -35,7 +35,7 @@ class CheckoutTest(APITest):
     def _get_common_payload(self, basket_url):
         return {
             "basket": basket_url,
-            "guest_email": "henk@example.com",
+            "email": "henk@example.com",
             "total": "50.00",
             "shipping_method_code": "no-shipping-required",
             "shipping_charge": {"currency": "EUR", "excl_tax": "0.00", "tax": "0.00"},
@@ -96,9 +96,8 @@ class CheckoutTest(APITest):
         response = self.post("api-checkout", **payload)
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(
-            response.data["guest_email"],
-            "",
-            "Guest email should be blank since user was authenticated",
+            response.data["email"],
+            "nobody@nobody.niks",
         )
         self.assertEqual(
             Basket.objects.get(pk=basket["id"]).status,
@@ -131,9 +130,8 @@ class CheckoutTest(APITest):
         )
         self.assertEqual(response.status_code, 200, response.data)
         self.assertEqual(
-            response.data["guest_email"],
-            "",
-            "Guest email should be blank since user was authenticated",
+            response.data["email"],
+            "nobody@nobody.niks",
         )
         self.assertEqual(
             Basket.objects.get(pk=basket["id"]).status,
@@ -347,7 +345,6 @@ class CheckoutTest(APITest):
         basket = response.data
 
         payload = self._get_common_payload(basket["url"])
-        del payload["guest_email"]
 
         with self.settings(OSCAR_ALLOW_ANON_CHECKOUT=True):
             response = self.post("api-checkout", **payload)
@@ -372,7 +369,7 @@ class CheckoutTest(APITest):
             payload["guest_email"] = "henk@example.com"
             response = self.post("api-checkout", **payload)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.data["guest_email"], "henk@example.com")
+            self.assertEqual(response.data["email"], "henk@example.com")
             self.assertEqual(
                 Basket.objects.get(pk=basket["id"]).status,
                 "Frozen",


### PR DESCRIPTION
When no user is attached to the order the email property will be the order.guest_email.
When a user is attached to the order the email property will be the order.user.email
A this moment there is no way of getting the order email via the api because the user serializer doesn't have a email field

for some reason the communication app was not in the sandbox installed apps. I couldn't migrate and test without this.
