### PR TITLE
Make product slug optional

### DIFF
--- a/oscarapi/serializers/admin/product.py
+++ b/oscarapi/serializers/admin/product.py
@@ -45,6 +45,7 @@ class AdminProductSerializer(BaseProductSerializer):
         required=False,
         queryset=Product.objects.filter(structure=Product.CHILD),
     )
+    slug = serializers.SlugField(required=False)
 
     class Meta(BaseProductSerializer.Meta):
         exclude = ("product_options",)


### PR DESCRIPTION
It's a slug field and it creates the slug by itself if not specified. Currently, you have to specify the slug manually even if you are happy with the auto-generated one.