### PR TITLE
Split user detail views for end-users and the Admin API

### DIFF
--- a/docs/source/usage/settings.rst
+++ b/docs/source/usage/settings.rst
@@ -13,6 +13,12 @@ Default: ``True``
 
 Useful in production websites wehere you want to make sure that the admin api is not exposed at all.
 
+``OSCARAPI_EXPOSE_USER_DETAILS``
+-----------------------------------
+Default: ``True``
+
+The ``Login`` view (``GET``) and the ``owner`` field in the ``BasketSerializer``and ``CheckoutSerializer`` expose user details, like username and email address. With this setting you can enable/disable this behaviour.
+
 Serializer settings
 ===================
 

--- a/docs/source/usage/settings.rst
+++ b/docs/source/usage/settings.rst
@@ -15,7 +15,7 @@ Useful in production websites wehere you want to make sure that the admin api is
 
 ``OSCARAPI_EXPOSE_USER_DETAILS``
 -----------------------------------
-Default: ``True``
+Default: ``False``
 
 The ``Login`` view (``GET``) and the ``owner`` field in the ``BasketSerializer``and ``CheckoutSerializer`` expose user details, like username and email address. With this setting you can enable/disable this behaviour.
 

--- a/oscarapi/serializers/admin/user.py
+++ b/oscarapi/serializers/admin/user.py
@@ -1,0 +1,19 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework import serializers
+
+from oscarapi.utils.settings import overridable
+
+User = get_user_model()
+
+
+class AdminUserSerializer(serializers.ModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="admin-user-detail")
+    date_joined = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = User
+        fields = overridable(
+            "OSCARAPI_ADMIN_USER_FIELDS",
+            default=("url", User.USERNAME_FIELD, "email", "date_joined"),
+        )

--- a/oscarapi/serializers/login.py
+++ b/oscarapi/serializers/login.py
@@ -13,10 +13,13 @@ def field_length(fieldname):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    date_joined = serializers.DateTimeField(read_only=True)
+
     class Meta:
         model = User
         fields = overridable(
-            "OSCARAPI_USER_FIELDS", default=(User.USERNAME_FIELD, "id", "date_joined")
+            "OSCARAPI_USER_FIELDS",
+            default=(User.USERNAME_FIELD, "email", "date_joined"),
         )
 
 

--- a/oscarapi/tests/unit/testbasket.py
+++ b/oscarapi/tests/unit/testbasket.py
@@ -1026,14 +1026,13 @@ class BasketTest(APITest):
     def test_header_login_does_not_cause_regular_login(self):
         "Prove that there is not a bug in the test client that logs a user in when doing hlogin."
         self.hlogin("nobody", "nobody", session_id="nobody")
-        with self.settings(DEBUG=True):
-            self.response = self.get("api-login")
-            self.response.assertStatusEqual(204)
-            self.response = self.get(
-                "api-login", session_id="nobody", authenticated=True
-            )
-            self.response.assertStatusEqual(200)
-            self.response.assertValueEqual("username", "nobody")
+        self.response = self.get("api-login")
+        self.response.assertStatusEqual(405)
+        self.response = self.get(
+            "api-login", session_id="nobody", authenticated=True
+        )
+        self.response.assertStatusEqual(200)
+        self.response.assertValueEqual("username", "nobody")
 
     def test_add_product_limit_basket(self):
         """Test if an anonymous user cannot add more than two products to his

--- a/oscarapi/tests/unit/testbasket.py
+++ b/oscarapi/tests/unit/testbasket.py
@@ -1023,17 +1023,6 @@ class BasketTest(APITest):
         self.response = self.get(url, session_id="nobody", authenticated=True)
         self.response.assertStatusEqual(404)
 
-    def test_header_login_does_not_cause_regular_login(self):
-        "Prove that there is not a bug in the test client that logs a user in when doing hlogin."
-        self.hlogin("nobody", "nobody", session_id="nobody")
-        self.response = self.get("api-login")
-        self.response.assertStatusEqual(405)
-        self.response = self.get(
-            "api-login", session_id="nobody", authenticated=True
-        )
-        self.response.assertStatusEqual(200)
-        self.response.assertValueEqual("username", "nobody")
-
     def test_add_product_limit_basket(self):
         """Test if an anonymous user cannot add more than two products to his
         basket when amount of baskets is limited

--- a/oscarapi/tests/unit/testlogin.py
+++ b/oscarapi/tests/unit/testlogin.py
@@ -212,6 +212,13 @@ class LoginTest(APITest):
         self.response.assertStatusEqual(200)
         self.response.assertValueEqual("username", "nobody")
 
+        with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+            self.response = self.get(
+                "api-login", session_id="nobody", authenticated=True
+            )
+            self.assertEqual(self.response.status_code, 204)
+            self.assertIsNone(self.response.data)
+
 
 class SessionTest(APITest):
     def test_get_session(self):

--- a/oscarapi/tests/unit/testlogin.py
+++ b/oscarapi/tests/unit/testlogin.py
@@ -22,18 +22,17 @@ class LoginTest(APITest):
         )
 
         # check authentication worked
-        with self.settings(DEBUG=True, OSCARAPI_USER_FIELDS=("username", "id")):
+        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
             response = self.get("api-login", session_id="koe", authenticated=True)
             parsed_response = response.data
 
             self.assertEqual(parsed_response["username"], "nobody")
-            self.assertEqual(parsed_response["id"], 2)
+            self.assertEqual(parsed_response["email"], "nobody@nobody.niks")
 
         # note that this shows that we can move a session from one user to the
         # other! This is the responsibility of the client application!
         with self.settings(
             OSCARAPI_BLOCK_ADMIN_API_ACCESS=False,
-            DEBUG=True,
             OSCARAPI_USER_FIELDS=("username", "id"),
         ):
             response = self.post(
@@ -54,7 +53,12 @@ class LoginTest(APITest):
 
             self.assertEqual(response.status_code, 200)
             self.assertEqual(parsed_response["username"], "admin")
-            self.assertEqual(parsed_response["id"], 1)
+            self.assertEqual(parsed_response["email"], "admin@admin.admin")
+
+            with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+                response = self.get("api-login", session_id="koe", authenticated=True)
+                self.assertEqual(response.status_code, 204)
+                self.assertIsNone(response.data)
 
     def test_failed_login_with_header(self):
         "Failed login should not upgrade to an authenticated session"
@@ -72,10 +76,9 @@ class LoginTest(APITest):
         )
 
         # check authentication didn't work
-        with self.settings(DEBUG=True, OSCARAPI_USER_FIELDS=("username", "id")):
+        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
             response = self.get("api-login")
-            self.assertFalse(response.content)
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 405)
 
     def test_login_without_header(self):
         "It should be possible to login using the normal cookie session"
@@ -87,19 +90,18 @@ class LoginTest(APITest):
         self.assertNotIn("Session-Id", response)
 
         # check authentication worked
-        with self.settings(DEBUG=True, OSCARAPI_USER_FIELDS=("username", "id")):
+        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
             response = self.get("api-login")
             parsed_response = response.data
 
             self.assertEqual(parsed_response["username"], "nobody")
-            self.assertEqual(parsed_response["id"], 2)
+            self.assertEqual(parsed_response["email"], "nobody@nobody.niks")
 
         # using cookie sessions it is not possible to pass 1 session to another
         # user
         with self.settings(
             OSCARAPI_BLOCK_ADMIN_API_ACCESS=False,
-            DEBUG=True,
-            OSCARAPI_USER_FIELDS=("username", "id"),
+            OSCARAPI_USER_FIELDS=("username", "email"),
         ):
             response = self.post("api-login", username="admin", password="admin")
 
@@ -112,7 +114,12 @@ class LoginTest(APITest):
             parsed_response = response.data
 
             self.assertEqual(parsed_response["username"], "nobody")
-            self.assertEqual(parsed_response["id"], 2)
+            self.assertEqual(parsed_response["email"], "nobody@nobody.niks")
+
+            with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+                response = self.get("api-login")
+                self.assertEqual(response.status_code, 204)
+                self.assertIsNone(response.data)
 
     def test_logged_in_users_can_not_login_again_via_the_api(self):
         "It should not be possible to move a cookie session to a header session"
@@ -165,7 +172,7 @@ class LoginTest(APITest):
             }
             session_id = session_id_from_parsed_session_uri(parsed_session_uri)
             self.assertTrue(session.exists(session_id))
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 405)
 
             # delete the session
             response = self.delete("api-login", session_id="koe")
@@ -188,14 +195,22 @@ class LoginTest(APITest):
             self.assertFalse(session.exists(session_id))
 
             response = self.get("api-login")
-
-            self.assertEqual(response.status_code, 204)
+            self.assertEqual(response.status_code, 405)
 
     def test_can_not_start_authenticated_sessions_unauthenticated(self):
         "While anonymous session will just be started when not existing yet, authenticated ones can only be created by loggin in"
         with self.settings(DEBUG=True, SESSION_SAVE_EVERY_REQUEST=True):
             response = self.get("api-login", session_id="koe", authenticated=True)
             self.assertEqual(response.status_code, 401)
+
+    def test_header_login_does_not_cause_regular_login(self):
+        "Prove that there is not a bug in the test client that logs a user in when doing hlogin."
+        self.hlogin("nobody", "nobody", session_id="nobody")
+        self.response = self.get("api-login")
+        self.response.assertStatusEqual(405)
+        self.response = self.get("api-login", session_id="nobody", authenticated=True)
+        self.response.assertStatusEqual(200)
+        self.response.assertValueEqual("username", "nobody")
 
 
 class SessionTest(APITest):

--- a/oscarapi/tests/unit/testuser.py
+++ b/oscarapi/tests/unit/testuser.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
 
 from oscarapi.tests.utils import APITest
 
@@ -30,3 +32,39 @@ class UserTest(APITest):
 
     def test_non_admin_header(self):
         self.hlogin("nobody", "nobody", "nobody")
+
+
+class UserDetailTest(APITest):
+    """
+    Check if we can access our own user details when authenticated and when
+    OSCARAPI_EXPOSE_USER_DETAILS is set to True
+    """
+
+    def test_expose_user_detail_allowed(self):
+        "The user nobody can retrieve it's own user details"
+        self.login("nobody", "nobody")
+        user = User.objects.get(username="nobody")
+        url = reverse("user-detail", args=(user.id,))
+
+        self.response = self.get(url)
+        self.response.assertStatusEqual(200)
+        self.response.assertValueEqual("username", user.username)
+
+    def test_expose_user_detail_from_other_users_not_found(self):
+        "The user nobody cannot retrieve other users details"
+        self.login("nobody", "nobody")
+        url = reverse("user-detail", args=(1,))
+
+        self.response = self.get(url)
+        self.response.assertStatusEqual(404)
+
+    @override_settings(OSCARAPI_EXPOSE_USER_DETAILS=False)
+    def test_expose_user_detail_not_allowed(self):
+        "The user nobody can not retrieve it's own user details (disabled)"
+        self.login("nobody", "nobody")
+        user = User.objects.get(username="nobody")
+        url = reverse("user-detail", args=(user.id,))
+
+        self.response = self.get(url)
+        self.response.assertStatusEqual(204)
+        self.assertIsNone(self.response.data)

--- a/oscarapi/urls.py
+++ b/oscarapi/urls.py
@@ -6,7 +6,7 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from oscarapi.utils.loading import get_api_classes, get_api_class
 
 api_root = get_api_class("views.root", "api_root")
-LoginView = get_api_class("views.login", "LoginView")
+(LoginView, UserDetail) = get_api_classes("views.login", ["LoginView", "UserDetail"])
 (
     BasketView,
     AddProductView,
@@ -26,7 +26,6 @@ LoginView = get_api_class("views.login", "LoginView")
     ],
 )
 
-(UserList, UserDetail) = get_api_classes("views.admin.user", ["UserList", "UserDetail"])
 (StockRecordDetail, PartnerList, PartnerDetail) = get_api_classes(
     "views.admin.partner", ["StockRecordDetail", "PartnerList", "PartnerDetail"]
 )
@@ -144,6 +143,10 @@ LoginView = get_api_class("views.login", "LoginView")
         "OrderLineAdminDetail",
         "OrderLineAttributeAdminDetail",
     ],
+)
+
+(UserAdminList, UserAdminDetail) = get_api_classes(
+    "views.admin.user", ["UserAdminList", "UserAdminDetail"]
 )
 
 
@@ -299,7 +302,8 @@ admin_urlpatterns = [
         OrderLineAttributeAdminDetail.as_view(),
         name="admin-order-lineattributes-detail",
     ),
-    path("users/", UserList.as_view(), name="admin-user-list"),
+    path("users/", UserAdminList.as_view(), name="admin-user-list"),
+    path("users/<int:pk>/", UserAdminDetail.as_view(), name="admin-user-detail"),
 ]
 
 if not getattr(settings, "OSCARAPI_BLOCK_ADMIN_API_ACCESS", True):

--- a/oscarapi/views/admin/user.py
+++ b/oscarapi/views/admin/user.py
@@ -4,23 +4,23 @@ from rest_framework import generics
 
 
 APIAdminPermission = get_api_class("permissions", "APIAdminPermission")
-UserSerializer = get_api_class("serializers.login", "UserSerializer")
+AdminUserSerializer = get_api_class("serializers.admin.user", "AdminUserSerializer")
 User = get_user_model()
 
 
-class UserList(generics.ListCreateAPIView):
+class UserAdminList(generics.ListCreateAPIView):
     """
     List of all users, either frontend or admin users.
-    The fields shown in this view can be changed using the ``OSCARAPI_USER_FIELDS``
+    The fields shown in this view can be changed using the ``OSCARAPI_ADMIN_USER_FIELDS``
     setting
     """
 
     queryset = User.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = AdminUserSerializer
     permission_classes = (APIAdminPermission,)
 
 
-class UserDetail(generics.RetrieveUpdateDestroyAPIView):
+class UserAdminDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = User.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = AdminUserSerializer
     permission_classes = (APIAdminPermission,)

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -1,6 +1,9 @@
 from django.conf import settings
-from rest_framework import status
+from django.contrib.auth import get_user_model
+
+from rest_framework import generics, status
 from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -14,8 +17,9 @@ LoginSerializer, UserSerializer = get_api_classes(
 )
 
 Basket = get_model("basket", "Basket")
+User = get_user_model()
 
-__all__ = ("LoginView",)
+__all__ = ("LoginView", "UserDetail")
 
 
 class LoginView(APIView):
@@ -111,3 +115,16 @@ class LoginView(APIView):
         request.session = None
 
         return Response("")
+
+
+class UserDetail(generics.RetrieveAPIView):
+    serializer_class = UserSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_queryset(self):
+        return User.objects.filter(pk=self.request.user.pk)
+
+    def get(self, request, *args, **kwargs):
+        if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", True):
+            return super().get(request, *args, **kwargs)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -56,7 +56,7 @@ class LoginView(APIView):
 
     def get(self, request, *args, **kwargs):
         if request.user.is_authenticated:
-            if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", True):
+            if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", False):
                 ser = UserSerializer(request.user, many=False)
                 return Response(ser.data)
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -125,6 +125,6 @@ class UserDetail(generics.RetrieveAPIView):
         return User.objects.filter(pk=self.request.user.pk)
 
     def get(self, request, *args, **kwargs):
-        if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", True):
+        if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", False):
             return super().get(request, *args, **kwargs)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -45,10 +45,11 @@ class LoginView(APIView):
     6. A response will be issued containing the new session id as a header
        (only when the request contained the session header as well).
 
-    GET (enabled in DEBUG mode only):
-    Get the details of the logged in user.
-    If more details are needed, use the ``OSCARAPI_USER_FIELDS`` setting to change
-    the fields the ``UserSerializer`` will render.
+    GET:
+    Get the details of the logged in user. Can be disabled with the
+    OSCARAPI_EXPOSE_USER_DETAILS setting. If more details are needed,
+    use the ``OSCARAPI_USER_FIELDS`` setting to change the fields the
+    ``UserSerializer`` will render.
     """
 
     serializer_class = LoginSerializer

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -54,12 +54,11 @@ class LoginView(APIView):
     serializer_class = LoginSerializer
 
     def get(self, request, *args, **kwargs):
-        if settings.DEBUG:
-            if request.user.is_authenticated:
+        if request.user.is_authenticated:
+            if getattr(settings, "OSCARAPI_EXPOSE_USER_DETAILS", True):
                 ser = UserSerializer(request.user, many=False)
                 return Response(ser.data)
             return Response(status=status.HTTP_204_NO_CONTENT)
-
         raise MethodNotAllowed("GET")
 
     def merge_baskets(self, anonymous_basket, basket):

--- a/sandbox/settings/sandbox.py
+++ b/sandbox/settings/sandbox.py
@@ -192,4 +192,6 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
+OSCARAPI_EXPOSE_USER_DETAILS = True
+
 from oscar.defaults import *  # noqa


### PR DESCRIPTION
Use a separate user view (and serializer) for regular users and Admin API users. Allow user details to be visible, which can be controlled with a setting. See also #241 

Todo:
- [x] Extend tests for the owner field (to make sure it is accessible now)
- [x] Add documentation
