### PR TITLE
Prevent SuspiciousFileOperation being throw on ImageUrlField

### DIFF
--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -345,7 +345,7 @@ class ImageUrlField(serializers.ImageField):
                     path = join(
                         settings.MEDIA_ROOT, location.replace(settings.MEDIA_URL, "", 1)
                     )
-                    file_object = File(open(path, "rb"))
+                    file_object = File(open(path, "rb"), name=basename(parsed_url.path))
 
                 return super(ImageUrlField, self).to_internal_value(file_object)
 


### PR DESCRIPTION
Recently I saw an SuspiciousFileOperation exception and this is because Django has added some file protections a while back. This fixes it and I also added a test that proves the error in the old situation (before this PR).