### PR TITLE
remove 'Django>=2.2.24' from setup.py->install_requires because first…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     install_requires=[
         "setuptools",
         "django-oscar>=3.0",
-        "Django>=2.2.24",  # CVE-2021-33203
         "djangorestframework>=3.9",  # first version to support Django 2.2
     ],
     # mark test target to require extras.


### PR DESCRIPTION
because firstly it's breaking the sandbox secondly it's redundant since a correct version of django will be installed with oscar anyways

#285 