### PR TITLE
Do not completely delete the session when logging out

### DIFF
--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -107,6 +107,7 @@ class HeaderSessionMiddleware(SessionMiddleware, IsApiRequest):
             self.is_api_request(request)
             and getattr(request, "session", None) is not None
             and hasattr(request, "parsed_session_uri")
+            and request.session.session_key is not None
         ):
             session_key = request.session.session_key
             parsed_session_key = session_id_from_parsed_session_uri(

--- a/oscarapi/views/login.py
+++ b/oscarapi/views/login.py
@@ -114,9 +114,7 @@ class LoginView(APIView):
             if basket:
                 operations.flush_and_delete_basket(basket)
 
-        request.session.clear()
-        request.session.delete()
-        request.session = None
+        request.session.flush()
 
         return Response("")
 


### PR DESCRIPTION
Only flush the session when logging out, so only the data from the session is deleted and not the whole session. This way the `SessionMiddleware` is still able to delete the associated session cookie. 

When the session is completely deleted the `try..except AttributeError` clause will return the response immediately without deleting the cookie, see below.

Taken from [django/contrib/sessions/middleware.py](https://github.com/django/django/blob/cfe3008123ed7c9e3f3a4d51d4a22f9d96634e33/django/contrib/sessions/middleware.py#L22-L42):
```python
    def process_response(self, request, response):
        """
        If request.session was modified, or if the configuration is to save the
        session every time, save the changes and set a session cookie or delete
        the session cookie if the session has been emptied.
        """
        try:
            accessed = request.session.accessed
            modified = request.session.modified
            empty = request.session.is_empty()
        except AttributeError:
            return response
        # First check if we need to delete this cookie.
        # The session should be deleted only if the session is entirely empty.
        if settings.SESSION_COOKIE_NAME in request.COOKIES and empty:
            response.delete_cookie(
                settings.SESSION_COOKIE_NAME,
                path=settings.SESSION_COOKIE_PATH,
                domain=settings.SESSION_COOKIE_DOMAIN,
                samesite=settings.SESSION_COOKIE_SAMESITE,
            )
```            