### PR TITLE
fixes get_api_class not finding modules registered with OSCARAPI_OVERRIDE_MODULES

### DIFF
--- a/oscarapi/tests/unit/test_get_api_class.py
+++ b/oscarapi/tests/unit/test_get_api_class.py
@@ -21,7 +21,7 @@ class ApiOverrideTest(APITest):
         )
 
         # now get the serializer again, but with the OSCARAPI_OVERRIDE_MODULES
-        with patch.object(loading, "OSCARAPI_OVERRIDE_MODULES", ["oscarapi.tests"]):
+        with self.settings(OSCARAPI_OVERRIDE_MODULES=["oscarapi.tests"]):
             my_login_serializer = self.get_login_serializer()
             login_data = my_login_serializer(instance=user).data
             self.assertIn(

--- a/oscarapi/utils/loading.py
+++ b/oscarapi/utils/loading.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from oscar.core.loading import _pluck_classes, _import_module
 
 
-
 def oscarapi_class_loader(module_label, classnames, module_prefix="oscarapi"):
     """Oscarapi uses a bit simpler method of overrides"""
     default_module_name = "%s.%s" % (module_prefix, module_label)

--- a/oscarapi/utils/loading.py
+++ b/oscarapi/utils/loading.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from oscar.core.loading import _pluck_classes, _import_module
 
-OSCARAPI_OVERRIDE_MODULES = getattr(settings, "OSCARAPI_OVERRIDE_MODULES", [])
 
 
 def oscarapi_class_loader(module_label, classnames, module_prefix="oscarapi"):
@@ -9,6 +8,8 @@ def oscarapi_class_loader(module_label, classnames, module_prefix="oscarapi"):
     default_module_name = "%s.%s" % (module_prefix, module_label)
     default_module = _import_module(default_module_name, classnames)
     class_search_modules = []
+
+    OSCARAPI_OVERRIDE_MODULES = getattr(settings, "OSCARAPI_OVERRIDE_MODULES", [])
 
     # load all modules to search for classes in
     for module_name in OSCARAPI_OVERRIDE_MODULES:  # could be empty


### PR DESCRIPTION
When get_api_class or get_api_classes is imported in a file that is parsed during the django settings configuration, OSCARAPI_OVERRIDE_MODULES could be pinned to the wrong value.

get_api_class now reads the value from settings when it is called instead of statically defining it in the module. It is now safe to::

    from oscarapi.utils.loading import get_api_class, get_api_classes

In files that are parsed diring django setting configuration, avoiding ugly constructs such as::

    def load_api_stuff():
        from oscarapi.utils.loading import get_api_class, get_api_classes
        api_class = get_api_class(...)
        # eulgh