### PR TITLE
Fix images going over the max file size not being processed.

### DIFF
--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -326,7 +326,7 @@ class LazyRemoteFile(File):
         # Try to keep file in memory, but do not exceed FILE_UPLOAD_MAX_MEMORY_SIZE
         result_file = tempfile.SpooledTemporaryFile(
             max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE,
-            mode="wb",
+            mode="w+b",
             suffix=".upload" + ext,
             dir=settings.FILE_UPLOAD_TEMP_DIR,
         )

--- a/oscarapi/tests/unit/testproduct.py
+++ b/oscarapi/tests/unit/testproduct.py
@@ -1150,49 +1150,9 @@ class AdminProductSerializerTest(_ProductSerializerTest):
         image = obj.images.get()
         self.assertEqual(image.caption, "HA! IK HEET HARRIE")
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
-    def test_add_multiple_images(self, urlopen):
-        "Adding images should work just fine"
-        urlopen.return_value = open(
-            join(dirname(__file__), "testdata", "image.jpg"),
-            "rb",
-        )
-
-        product = Product.objects.get(pk=3)
-        self.assertEqual(product.images.count(), 0)
-
-        request = self.factory.get("%simages/nao-robot.jpg" % settings.STATIC_URL)
-        ser = AdminProductSerializer(
-            data={
-                "product_class": "t-shirt",
-                "slug": "oscar-t-shirt",
-                "description": "Henk",
-                "images": [
-                    {
-                        "original": "https://example.com/testdata/image.jpg",
-                        "caption": "HA! IK HEET HARRIE 1",
-                    },
-                    {
-                        "original": "https://example.com/testdata/image.jpg",
-                        "caption": "HA! IK HEET HARRIE 2",
-                    },
-                    {
-                        "original": "https://example.com/testdata/image.jpg",
-                        "caption": "HA! IK HEET HARRIE 3",
-                    },
-                    {
-                        "original": "https://example.com/testdata/image.jpg",
-                        "caption": "HA! IK HEET HARRIE 4",
-                    },
-                ],
-            },
-            instance=product,
-            context={"request": request},
-        )
-        self.assertTrue(ser.is_valid(raise_exception=True), "Something wrong %s" % ser.errors)
-        obj = ser.save()
-        self.assertEqual(obj.pk, 3, "product should be the same as passed as instance")
-        self.assertEqual(obj.images.count(), 4)
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=1)
+    def test_add_image_over_max_size_limit(self):
+        self.test_add_images()
 
     @override_settings(MEDIA_ROOT=tempfile.gettempdir())
     def test_add_local_image(self):


### PR DESCRIPTION
When you go over the max_size limit, the SpooledTemporaryFile creates a TemporaryFile.
But this TemporaryFile could not be read, because the mode was set to "wb" (write binary).