### PR TITLE
File downloader module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
           make install
       - name: Run the testsuite
         run: |
-      	  coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
-      	  coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
+          coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
+          coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Show all versions
         run: pip list
       - name: Run the testsuite
-        run: make coverage
+        run: |
+          pwd
+          pip freeze
+          make coverage
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,27 +37,20 @@ jobs:
         django-version: ["3.2"]
         oscar-version: ["3.2"]
     steps:
-      - name: Download src dir
-        uses: actions/download-artifact@v2
-        with:
-          name: src
-          path: ./src
-      - name: Setup Python 3.x
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-           python-version: ${{ matrix.python-version }}
-      - name: Install all dependencies
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
         run: |
           pip install "django~=${{ matrix.django-version }}.0"
           pip install "django-oscar~=${{ matrix.oscar-version }}.0"
           make install
-      - name: Show all versions
-        run: pip list
       - name: Run the testsuite
         run: |
-          pwd
-          pip freeze
-          make coverage
+      	  coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
+      	  coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,23 @@ jobs:
         django-version: ["3.2"]
         oscar-version: ["3.2"]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Download src dir
+        uses: actions/download-artifact@v2
+        with:
+          name: src
+          path: ./src
+      - name: Setup Python 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+           python-version: ${{ matrix.python-version }}
+      - name: Install all dependencies
         run: |
+          pip install -e .[dev]
           pip install "django~=${{ matrix.django-version }}.0"
           pip install "django-oscar~=${{ matrix.oscar-version }}.0"
           make install
+      - name: Show all versions
+        run: pip list
       - name: Run the testsuite
         run: |
           coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,7 @@ jobs:
       - name: Show all versions
         run: pip list
       - name: Run the testsuite
-        run: |
-          coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
-          coverage run --parallel sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
+        run: make coverage
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:

--- a/docs/source/topics/settings.rst
+++ b/docs/source/topics/settings.rst
@@ -4,6 +4,8 @@ Oscar API Settings
 
 .. _main-settings-label:
 
+.. automodule:: oscarapi.settings
+
 Main settings
 =============
 
@@ -12,6 +14,7 @@ Main settings
 Default: ``True``
 
 Useful in production websites where you want to make sure that the admin api is not exposed at all.
+:const:`oscarapi.settings.BLOCK_ADMIN_API_ACCESS`
 
 ``OSCARAPI_EXPOSE_USER_DETAILS``
 -----------------------------------
@@ -40,7 +43,9 @@ Changes the headers for the admin api when downloading images.
 Serializer settings
 ===================
 
-Most of the model serializers in Oscar API have a default set of fields to use in the REST API. If you customized the Oscar models you can reflect this customization by adding settings for this serializer.
+Most of the model serializers in Oscar API have a default set of fields to use
+in the REST API. If you customized the Oscar models you can reflect this
+customization by adding settings for this serializer.
 
 For example, the ``RecommendedProduct`` serializer is defined as following:
 
@@ -51,10 +56,7 @@ For example, the ``RecommendedProduct`` serializer is defined as following:
 
         class Meta:
             model = Product
-            fields = overridable(
-                'OSCARAPI_RECOMMENDED_PRODUCT_FIELDS',
-                default=('url',)
-            )
+            fields = settings.RECOMMENDED_PRODUCT_FIELDS
 
 When you add the following section to your ``settings.py`` you will add the 'title' field as well:
 
@@ -62,6 +64,8 @@ When you add the following section to your ``settings.py`` you will add the 'tit
 
     OSCARAPI_RECOMMENDED_PRODUCT_FIELDS = ('url', 'title')
 
+Note that you need to prefix the settings with ``OSCARAPI_`` to make them work
+in your django settings file.
 
 The following serializers have customizable field settings:
 

--- a/oscarapi/download/default.py
+++ b/oscarapi/download/default.py
@@ -1,0 +1,11 @@
+from urllib.request import Request
+
+from oscarapi import settings
+from oscarapi.utils.download import download_binary_file
+
+
+class RetrieveFileMixin:
+    def retrieve_file(self):
+        headers = settings.LAZY_REMOTE_FILE_REQUEST_HEADERS
+        request = Request(self.url, headers=headers)
+        return download_binary_file(request)

--- a/oscarapi/permissions.py
+++ b/oscarapi/permissions.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-
 from rest_framework.permissions import (
     BasePermission,
     IsAuthenticated,
@@ -7,6 +5,7 @@ from rest_framework.permissions import (
 )
 
 from oscarapi.basket.operations import request_allows_access_to
+from oscarapi import settings
 
 
 class IsOwner(IsAuthenticated):
@@ -41,10 +40,7 @@ class APIAdminPermission(DjangoModelPermissions):
 
     @staticmethod
     def disallowed_by_setting_and_request(request):
-        return (
-            getattr(settings, "OSCARAPI_BLOCK_ADMIN_API_ACCESS", True)
-            or not request.user.is_staff
-        )
+        return settings.BLOCK_ADMIN_API_ACCESS or not request.user.is_staff
 
     def has_permission(self, request, view):
         if self.disallowed_by_setting_and_request(request):

--- a/oscarapi/serializers/admin/user.py
+++ b/oscarapi/serializers/admin/user.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 
 from rest_framework import serializers
 
-from oscarapi.utils.settings import overridable
+from oscarapi import settings
 
 User = get_user_model()
 
@@ -13,7 +13,4 @@ class AdminUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = overridable(
-            "OSCARAPI_ADMIN_USER_FIELDS",
-            default=("url", User.USERNAME_FIELD, "email", "date_joined"),
-        )
+        fields = settings.ADMIN_USER_FIELDS

--- a/oscarapi/serializers/basket.py
+++ b/oscarapi/serializers/basket.py
@@ -7,8 +7,8 @@ from rest_framework import serializers
 
 from oscar.core.loading import get_model
 
+from oscarapi import settings
 from oscarapi.basket import operations
-from oscarapi.utils.settings import overridable
 from oscarapi.serializers.fields import (
     DrillDownHyperlinkedIdentityField,
     DrillDownHyperlinkedRelatedField,
@@ -33,10 +33,7 @@ Product = get_model("catalogue", "Product")
 class VoucherSerializer(OscarModelSerializer):
     class Meta:
         model = Voucher
-        fields = overridable(
-            "OSCARAPI_VOUCHER_FIELDS",
-            default=("name", "code", "start_datetime", "end_datetime"),
-        )
+        fields = settings.VOUCHER_FIELDS
 
 
 class OfferDiscountSerializer(
@@ -85,25 +82,7 @@ class BasketSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Basket
-        fields = overridable(
-            "OSCARAPI_BASKET_FIELDS",
-            default=(
-                "id",
-                "owner",
-                "status",
-                "lines",
-                "url",
-                "total_excl_tax",
-                "total_excl_tax_excl_discounts",
-                "total_incl_tax",
-                "total_incl_tax_excl_discounts",
-                "total_tax",
-                "currency",
-                "voucher_discounts",
-                "offer_discounts",
-                "is_tax_known",
-            ),
-        )
+        fields = settings.BASKET_FIELDS
 
 
 class LineAttributeSerializer(OscarHyperlinkedModelSerializer):
@@ -167,26 +146,7 @@ class BasketLineSerializer(OscarHyperlinkedModelSerializer):
 
     class Meta:
         model = Line
-        fields = overridable(
-            "OSCARAPI_BASKETLINE_FIELDS",
-            default=(
-                "url",
-                "product",
-                "quantity",
-                "attributes",
-                "price_currency",
-                "price_excl_tax",
-                "price_incl_tax",
-                "price_incl_tax_excl_discounts",
-                "price_excl_tax_excl_discounts",
-                "is_tax_known",
-                "warning",
-                "basket",
-                "stockrecord",
-                "date_created",
-                "date_updated",
-            ),
-        )
+        fields = settings.BASKETLINE_FIELDS
 
     def to_representation(self, obj):
         # This override is needed to reflect offer discounts or strategy

--- a/oscarapi/serializers/login.py
+++ b/oscarapi/serializers/login.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model, authenticate, password_validation
 from rest_framework import serializers
 
-from oscarapi.utils.settings import overridable
+from oscarapi import settings
 
 
 User = get_user_model()
@@ -19,10 +19,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = overridable(
-            "OSCARAPI_USER_FIELDS",
-            default=(User.USERNAME_FIELD, "email", "date_joined"),
-        )
+        fields = settings.USER_FIELDS
 
 
 class LoginSerializer(serializers.Serializer):

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -9,7 +9,7 @@ from oscar.core.loading import get_model
 
 from oscarapi.utils.exists import bound_unique_together_get_or_create_multiple
 from oscarapi.utils.loading import get_api_classes
-from oscarapi.utils.settings import overridable
+from oscarapi import settings
 from oscarapi.utils.files import file_hash
 from oscarapi.utils.exists import find_existing_attribute_option_group
 from oscarapi.utils.accessors import getitems
@@ -188,7 +188,7 @@ class OptionSerializer(OscarHyperlinkedModelSerializer):
 
     class Meta:
         model = Option
-        fields = overridable("OSCARAPI_OPTION_FIELDS", default="__all__")
+        fields = settings.OPTION_FIELDS
         list_serializer_class = UpdateForwardManyToManySerializer
 
 
@@ -258,10 +258,7 @@ class ProductAttributeValueSerializer(OscarModelSerializer):
     class Meta:
         model = ProductAttributeValue
         list_serializer_class = ProductAttributeValueListSerializer
-        fields = overridable(
-            "OSCARAPI_PRODUCT_ATTRIBUTE_VALUE_FIELDS",
-            default=("name", "value", "code", "product"),
-        )
+        fields = settings.PRODUCT_ATTRIBUTE_VALUE_FIELDS
 
 
 class ProductImageUpdateListSerializer(UpdateListSerializer):
@@ -304,7 +301,7 @@ class RecommmendedProductSerializer(OscarModelSerializer):
 
     class Meta:
         model = Product
-        fields = overridable("OSCARAPI_RECOMMENDED_PRODUCT_FIELDS", default=("url",))
+        fields = settings.RECOMMENDED_PRODUCT_FIELDS
 
 
 class ProductStockRecordSerializer(OscarModelSerializer):
@@ -383,28 +380,7 @@ class ChildProductSerializer(PublicProductSerializer):
     description = serializers.CharField(source="parent.description")
 
     class Meta(PublicProductSerializer.Meta):
-        fields = overridable(
-            "OSCARAPI_CHILDPRODUCTDETAIL_FIELDS",
-            default=(
-                "url",
-                "upc",
-                "id",
-                "title",
-                "structure",
-                # 'parent', 'description', 'images', are not included by default, but
-                # easily enabled by overriding OSCARAPI_CHILDPRODUCTDETAIL_FIELDS
-                # in your settings file
-                "date_created",
-                "date_updated",
-                "recommended_products",
-                "attributes",
-                "categories",
-                "product_class",
-                "price",
-                "availability",
-                "options",
-            ),
-        )
+        fields = settings.CHILDPRODUCTDETAIL_FIELDS
 
 
 class ProductSerializer(PublicProductSerializer):
@@ -425,29 +401,7 @@ class ProductSerializer(PublicProductSerializer):
     )
 
     class Meta(PublicProductSerializer.Meta):
-        fields = overridable(
-            "OSCARAPI_PRODUCTDETAIL_FIELDS",
-            default=(
-                "url",
-                "upc",
-                "id",
-                "title",
-                "description",
-                "structure",
-                "date_created",
-                "date_updated",
-                "recommended_products",
-                "attributes",
-                "categories",
-                "product_class",
-                "images",
-                "price",
-                "availability",
-                "stockrecords",
-                "options",
-                "children",
-            ),
-        )
+        fields = settings.PRODUCTDETAIL_FIELDS
 
 
 class ProductLinkSerializer(ProductSerializer):
@@ -459,9 +413,7 @@ class ProductLinkSerializer(ProductSerializer):
     """
 
     class Meta(PublicProductSerializer.Meta):
-        fields = overridable(
-            "OSCARAPI_PRODUCT_FIELDS", default=("url", "id", "upc", "title")
-        )
+        fields = settings.PRODUCT_FIELDS
 
 
 class OptionValueSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/oscarapi/settings.py
+++ b/oscarapi/settings.py
@@ -1,3 +1,10 @@
+"""
+All oscarapi settings are defined in :mod:`oscarapi.settings`.
+
+To set these settings in you django `settings.py` file, prefix them with
+`OSCARAPI_`. So :const:`oscarapi.settings.EXPOSE_USER_DETAILS` becomes:
+`OSCARAPI_EXPOSE_USER_DETAILS`
+"""
 from django.contrib.auth import get_user_model
 from oscarapi.utils.settings import overridable
 from oscarapi import version
@@ -5,11 +12,35 @@ from oscarapi import version
 User = get_user_model()
 
 
+#: :const: OSCARAPI_BLOCK_ADMIN_API_ACCESS is useful in production websites where you
+#: want to make sure that the admin api is not exposed at all.
 BLOCK_ADMIN_API_ACCESS = overridable("OSCARAPI_BLOCK_ADMIN_API_ACCESS", True)
+
+#: OSCARAPI_EXPOSE_USER_DETAILS
+#: The ``Login`` view (``GET``) and the ``owner`` field in the
+#: ``BasketSerializer`` and ``CheckoutSerializer`` expose user details, like
+#: username and email address. With this setting you can enable/disable this behaviour.
+EXPOSE_USER_DETAILS = overridable("OSCARAPI_EXPOSE_USER_DETAILS", False)
+
+#: Enables the ``register`` endpoint so it's possible to create new user accounts.
+ENABLE_REGISTRATION = overridable("OSCARAPI_ENABLE_REGISTRATION", False)
+
+#: Changes the headers for the admin api when downloading images.
+LAZY_REMOTE_FILE_REQUEST_HEADERS = overridable(
+    "OSCARAPI_LAZY_REMOTE_FILE_REQUEST_HEADERS",
+    default={"User-Agent": f"django-oscar-api/{version}"},
+)
+
+FILE_DOWNLOADER_MODULE = overridable(
+    "OSCARAPI_FILE_DOWNLOADER_MODULE", default="download.default"
+)
+
+
 VOUCHER_FIELDS = overridable(
     "OSCARAPI_VOUCHER_FIELDS",
     default=("name", "code", "start_datetime", "end_datetime"),
 )
+"ik ben harrie"
 BASKET_FIELDS = overridable(
     "OSCARAPI_BASKET_FIELDS",
     default=(
@@ -118,10 +149,6 @@ USERADDRESS_FIELDS = overridable(
         "country",
         "url",
     ),
-)
-LAZY_REMOTE_FILE_REQUEST_HEADERS = overridable(
-    "OSCARAPI_LAZY_REMOTE_FILE_REQUEST_HEADERS",
-    default={"User-Agent": f"django-oscar-api/{version}"},
 )
 USER_FIELDS = overridable(
     "OSCARAPI_USER_FIELDS",

--- a/oscarapi/settings.py
+++ b/oscarapi/settings.py
@@ -1,0 +1,189 @@
+from django.contrib.auth import get_user_model
+from oscarapi.utils.settings import overridable
+from oscarapi import version
+
+User = get_user_model()
+
+
+BLOCK_ADMIN_API_ACCESS = overridable("OSCARAPI_BLOCK_ADMIN_API_ACCESS", True)
+VOUCHER_FIELDS = overridable(
+    "OSCARAPI_VOUCHER_FIELDS",
+    default=("name", "code", "start_datetime", "end_datetime"),
+)
+BASKET_FIELDS = overridable(
+    "OSCARAPI_BASKET_FIELDS",
+    default=(
+        "id",
+        "owner",
+        "status",
+        "lines",
+        "url",
+        "total_excl_tax",
+        "total_excl_tax_excl_discounts",
+        "total_incl_tax",
+        "total_incl_tax_excl_discounts",
+        "total_tax",
+        "currency",
+        "voucher_discounts",
+        "offer_discounts",
+        "is_tax_known",
+    ),
+)
+BASKETLINE_FIELDS = overridable(
+    "OSCARAPI_BASKETLINE_FIELDS",
+    default=(
+        "url",
+        "product",
+        "quantity",
+        "attributes",
+        "price_currency",
+        "price_excl_tax",
+        "price_incl_tax",
+        "price_incl_tax_excl_discounts",
+        "price_excl_tax_excl_discounts",
+        "is_tax_known",
+        "warning",
+        "basket",
+        "stockrecord",
+        "date_created",
+        "date_updated",
+    ),
+)
+
+ORDERLINE_FIELDS = overridable(
+    "OSCARAPI_ORDERLINE_FIELDS",
+    default=(
+        "attributes",
+        "url",
+        "product",
+        "stockrecord",
+        "quantity",
+        "price_currency",
+        "price_excl_tax",
+        "price_incl_tax",
+        "price_incl_tax_excl_discounts",
+        "price_excl_tax_excl_discounts",
+        "order",
+    ),
+)
+SURCHARGE_FIELDS = overridable(
+    "OSCARAPI_SURCHARGE_FIELDS",
+    default=("name", "code", "incl_tax", "excl_tax"),
+)
+ORDER_FIELDS = overridable(
+    "OSCARAPI_ORDER_FIELDS",
+    default=(
+        "number",
+        "basket",
+        "url",
+        "lines",
+        "owner",
+        "billing_address",
+        "currency",
+        "total_incl_tax",
+        "total_excl_tax",
+        "shipping_incl_tax",
+        "shipping_excl_tax",
+        "shipping_address",
+        "shipping_method",
+        "shipping_code",
+        "status",
+        "email",
+        "date_placed",
+        "payment_url",
+        "offer_discounts",
+        "voucher_discounts",
+        "surcharges",
+    ),
+)
+INITIAL_ORDER_STATUS = overridable("OSCARAPI_INITIAL_ORDER_STATUS", default="new")
+USERADDRESS_FIELDS = overridable(
+    "OSCARAPI_USERADDRESS_FIELDS",
+    default=(
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "line1",
+        "line2",
+        "line3",
+        "line4",
+        "state",
+        "postcode",
+        "search_text",
+        "phone_number",
+        "notes",
+        "is_default_for_shipping",
+        "is_default_for_billing",
+        "country",
+        "url",
+    ),
+)
+LAZY_REMOTE_FILE_REQUEST_HEADERS = overridable(
+    "OSCARAPI_LAZY_REMOTE_FILE_REQUEST_HEADERS",
+    default={"User-Agent": f"django-oscar-api/{version}"},
+)
+USER_FIELDS = overridable(
+    "OSCARAPI_USER_FIELDS",
+    default=(User.USERNAME_FIELD, "email", "date_joined"),
+)
+OPTION_FIELDS = overridable("OSCARAPI_OPTION_FIELDS", default="__all__")
+PRODUCT_ATTRIBUTE_VALUE_FIELDS = overridable(
+    "OSCARAPI_PRODUCT_ATTRIBUTE_VALUE_FIELDS",
+    default=("name", "value", "code", "product"),
+)
+RECOMMENDED_PRODUCT_FIELDS = overridable(
+    "OSCARAPI_RECOMMENDED_PRODUCT_FIELDS", default=("url",)
+)
+CHILDPRODUCTDETAIL_FIELDS = overridable(
+    "OSCARAPI_CHILDPRODUCTDETAIL_FIELDS",
+    default=(
+        "url",
+        "upc",
+        "id",
+        "title",
+        "structure",
+        # 'parent', 'description', 'images', are not included by default, but
+        # easily enabled by overriding OSCARAPI_CHILDPRODUCTDETAIL_FIELDS
+        # in your settings file
+        "date_created",
+        "date_updated",
+        "recommended_products",
+        "attributes",
+        "categories",
+        "product_class",
+        "price",
+        "availability",
+        "options",
+    ),
+)
+PRODUCTDETAIL_FIELDS = overridable(
+    "OSCARAPI_PRODUCTDETAIL_FIELDS",
+    default=(
+        "url",
+        "upc",
+        "id",
+        "title",
+        "description",
+        "structure",
+        "date_created",
+        "date_updated",
+        "recommended_products",
+        "attributes",
+        "categories",
+        "product_class",
+        "images",
+        "price",
+        "availability",
+        "stockrecords",
+        "options",
+        "children",
+    ),
+)
+PRODUCT_FIELDS = overridable(
+    "OSCARAPI_PRODUCT_FIELDS", default=("url", "id", "upc", "title")
+)
+ADMIN_USER_FIELDS = overridable(
+    "OSCARAPI_ADMIN_USER_FIELDS",
+    default=("url", User.USERNAME_FIELD, "email", "date_joined"),
+)

--- a/oscarapi/tests/unit/testadminapi.py
+++ b/oscarapi/tests/unit/testadminapi.py
@@ -1,10 +1,10 @@
 from unittest import skipIf, skipUnless
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 from django.urls import reverse, NoReverseMatch
 
+from oscarapi import settings
 from oscarapi import urls
 from oscarapi.tests.utils import APITest
 
@@ -13,7 +13,7 @@ from oscarapi.permissions import APIAdminPermission
 User = get_user_model()
 
 
-@skipUnless(settings.OSCARAPI_BLOCK_ADMIN_API_ACCESS, "Admin API is disabled")
+@skipUnless(settings.BLOCK_ADMIN_API_ACCESS, "Admin API is disabled")
 class AdminAPIDisabledTest(APITest):
     def test_root_view(self):
         "The admin api views should not be in the root view"
@@ -56,7 +56,7 @@ class AdminAPIDisabledTest(APITest):
         )
 
 
-@skipIf(settings.OSCARAPI_BLOCK_ADMIN_API_ACCESS, "Admin API is enabled")
+@skipIf(settings.BLOCK_ADMIN_API_ACCESS, "Admin API is enabled")
 class AdminAPIEnabledTest(APITest):
     def test_root_view(self):
         "The admin api views should be available in the root view"

--- a/oscarapi/tests/unit/testlogin.py
+++ b/oscarapi/tests/unit/testlogin.py
@@ -25,7 +25,7 @@ class LoginTest(APITest):
         )
 
         # check authentication worked
-        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
+        with patch("oscarapi.settings", USER_FIELDS=("username", "email")):
             response = self.get("api-login", session_id="koe", authenticated=True)
             parsed_response = response.data
 
@@ -34,9 +34,10 @@ class LoginTest(APITest):
 
         # note that this shows that we can move a session from one user to the
         # other! This is the responsibility of the client application!
-        with self.settings(
-            OSCARAPI_BLOCK_ADMIN_API_ACCESS=False,
-            OSCARAPI_USER_FIELDS=("username", "id"),
+        with patch(
+            "oscarapi.settings",
+            BLOCK_ADMIN_API_ACCESS=False,
+            USER_FIELDS=("username", "id"),
         ):
             response = self.post(
                 "api-login", username="admin", password="admin", session_id="koe"
@@ -58,7 +59,7 @@ class LoginTest(APITest):
             self.assertEqual(parsed_response["username"], "admin")
             self.assertEqual(parsed_response["email"], "admin@admin.admin")
 
-            with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+            with patch("oscarapi.views.login.settings", EXPOSE_USER_DETAILS=False):
                 response = self.get("api-login", session_id="koe", authenticated=True)
                 self.assertEqual(response.status_code, 204)
                 self.assertIsNone(response.data)
@@ -79,7 +80,7 @@ class LoginTest(APITest):
         )
 
         # check authentication didn't work
-        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
+        with patch("oscarapi.settings", USER_FIELDS=("username", "email")):
             response = self.get("api-login")
             self.assertEqual(response.status_code, 405)
 
@@ -93,7 +94,7 @@ class LoginTest(APITest):
         self.assertNotIn("Session-Id", response)
 
         # check authentication worked
-        with self.settings(OSCARAPI_USER_FIELDS=("username", "email")):
+        with patch("oscarapi.settings", USER_FIELDS=("username", "email")):
             response = self.get("api-login")
             parsed_response = response.data
 
@@ -102,9 +103,10 @@ class LoginTest(APITest):
 
         # using cookie sessions it is not possible to pass 1 session to another
         # user
-        with self.settings(
-            OSCARAPI_BLOCK_ADMIN_API_ACCESS=False,
-            OSCARAPI_USER_FIELDS=("username", "email"),
+        with patch(
+            "oscarapi.settings",
+            BLOCK_ADMIN_API_ACCESS=False,
+            USER_FIELDS=("username", "email"),
         ):
             response = self.post("api-login", username="admin", password="admin")
 
@@ -119,7 +121,7 @@ class LoginTest(APITest):
             self.assertEqual(parsed_response["username"], "nobody")
             self.assertEqual(parsed_response["email"], "nobody@nobody.niks")
 
-            with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+            with patch("oscarapi.views.login.settings", EXPOSE_USER_DETAILS=False):
                 response = self.get("api-login")
                 self.assertEqual(response.status_code, 204)
                 self.assertIsNone(response.data)
@@ -215,7 +217,7 @@ class LoginTest(APITest):
         self.response.assertStatusEqual(200)
         self.response.assertValueEqual("username", "nobody")
 
-        with self.settings(OSCARAPI_EXPOSE_USER_DETAILS=False):
+        with patch("oscarapi.views.login.settings", EXPOSE_USER_DETAILS=False):
             self.response = self.get(
                 "api-login", session_id="nobody", authenticated=True
             )
@@ -273,7 +275,7 @@ class SessionTest(APITest):
 
 class RegistrationTest(APITest):
     def test_registration_disabled(self):
-        with self.settings(OSCARAPI_ENABLE_REGISTRATION=False):
+        with patch("oscarapi.views.login.settings", ENABLE_REGISTRATION=False):
             self.response = self.post(
                 "api-register",
                 email="someone@email.com",

--- a/oscarapi/tests/unit/testproduct.py
+++ b/oscarapi/tests/unit/testproduct.py
@@ -784,7 +784,7 @@ class ProductAttributeValueSerializerTest(_ProductSerializerTest):
             ser.errors, {"value": ["multioption: Option geit,kip does not exist."]}
         )
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_productattributevalueserializer_image(self, urlopen):
         urlopen.return_value = open(
             join(dirname(__file__), "testdata", "image.jpg"),
@@ -809,7 +809,7 @@ class ProductAttributeValueSerializerTest(_ProductSerializerTest):
         p.refresh_from_db()
         self.assertTrue(p.attribute_values.filter(attribute__code="image").exists())
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_productattributevalueserializer_file(self, urlopen):
         urlopen.return_value = open(
             join(dirname(__file__), "testdata", "test.pdf"),
@@ -1116,7 +1116,7 @@ class AdminProductSerializerTest(_ProductSerializerTest):
 
         self.assertFalse(ser.is_valid(), "This test should fail the uniqueness test.")
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_add_images(self, urlopen):
         "Adding images should work just fine"
         urlopen.return_value = open(
@@ -1188,7 +1188,7 @@ class AdminProductSerializerTest(_ProductSerializerTest):
         image = obj.images.get()
         self.assertEqual(image.caption, "HA! IK HEET HARRIE")
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_add_broken_image(self, urlopen):
         urlopen.side_effect = HTTPError(
             url="https://example.com/testdata/image.jpg",
@@ -1224,7 +1224,7 @@ class AdminProductSerializerTest(_ProductSerializerTest):
         product.refresh_from_db()
         self.assertEqual(product.images.count(), 0)
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_modify_images(self, urlopen):
         "The serializer should automatically detect that an image already exists and update it"
         urlopen.return_value = open(
@@ -1263,7 +1263,7 @@ class AdminProductSerializerTest(_ProductSerializerTest):
         self.assertEqual(image.caption, "HA! IK HEET HARRIE")
         self.assertEqual(image.original.name, "images/products/2019/05/image.jpg")
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_modify_images_with_hash(self, urlopen):
         "When a hash is included in the url, the serializer should not try to download an image that is allready present locally."
         urlopen.return_value.side_effect = Exception(
@@ -1756,7 +1756,7 @@ class TestProductAdmin(APITest):
         )
         self.assertEqual(str(e.exception), msg)
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_image_error(self, urlopen):
         urlopen.side_effect = HTTPError(
             url="https://example.com/testdata/image.jpg",
@@ -2021,7 +2021,7 @@ class AdminCategoryApiTest(APITest):
         "productimage",
     ]
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_create_category_and_ancestors(self, urlopen):
         urlopen.return_value = open(
             join(dirname(__file__), "testdata", "image.jpg"), "rb"
@@ -2063,7 +2063,7 @@ class AdminCategoryApiTest(APITest):
         self.response.assertStatusEqual(201)
         self.assertEqual(self.response["description"], "Klak")
 
-    @mock.patch("oscarapi.serializers.fields.urlopen")
+    @mock.patch("oscarapi.utils.download.urlopen")
     def test_create_root_category(self, urlopen):
         urlopen.return_value = open(
             join(dirname(__file__), "testdata", "image.jpg"),

--- a/oscarapi/tests/unit/testuser.py
+++ b/oscarapi/tests/unit/testuser.py
@@ -1,3 +1,4 @@
+from mock import patch
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -58,13 +59,14 @@ class UserDetailTest(APITest):
         self.response = self.get(url)
         self.response.assertStatusEqual(404)
 
-    @override_settings(OSCARAPI_EXPOSE_USER_DETAILS=False)
+    # @override_settings(OSCARAPI_EXPOSE_USER_DETAILS=False)
     def test_expose_user_detail_not_allowed(self):
         "The user nobody can not retrieve it's own user details (disabled)"
-        self.login("nobody", "nobody")
-        user = User.objects.get(username="nobody")
-        url = reverse("user-detail", args=(user.id,))
+        with patch("oscarapi.views.login.settings", EXPOSE_USER_DETAILS=False):
+            self.login("nobody", "nobody")
+            user = User.objects.get(username="nobody")
+            url = reverse("user-detail", args=(user.id,))
 
-        self.response = self.get(url)
-        self.response.assertStatusEqual(204)
-        self.assertIsNone(self.response.data)
+            self.response = self.get(url)
+            self.response.assertStatusEqual(204)
+            self.assertIsNone(self.response.data)

--- a/oscarapi/tests/unit/testvoucher.py
+++ b/oscarapi/tests/unit/testvoucher.py
@@ -74,3 +74,20 @@ class VoucherTest(APITest):
 
         self.response = self.post("api-basket-add-voucher", vouchercode="testvoucher")
         self.response.assertStatusEqual(200)
+
+
+class VoucherWithOfferTest(APITest):
+    fixtures = [
+        "productcategory",
+        "productclass",
+        "product",
+        "category",
+        "partner",
+        "productattribute",
+        "productattributevalue",
+        "stockrecord",
+        "offer",
+        "attributeoption",
+        "voucher",
+        "attributeoptiongroup",
+    ]

--- a/oscarapi/urls.py
+++ b/oscarapi/urls.py
@@ -1,8 +1,8 @@
 # pylint: disable=unbalanced-tuple-unpacking
-from django.conf import settings
 from django.urls import include, path, re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
+from oscarapi import settings
 from oscarapi.utils.loading import get_api_classes, get_api_class
 
 api_root = get_api_class("views.root", "api_root")
@@ -308,7 +308,7 @@ admin_urlpatterns = [
     path("users/<int:pk>/", UserAdminDetail.as_view(), name="admin-user-detail"),
 ]
 
-if not getattr(settings, "OSCARAPI_BLOCK_ADMIN_API_ACCESS", True):
+if not settings.BLOCK_ADMIN_API_ACCESS:
     urlpatterns.append(path("admin/", include(admin_urlpatterns)))
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/oscarapi/utils/download.py
+++ b/oscarapi/utils/download.py
@@ -1,0 +1,39 @@
+from os.path import splitext
+import shutil
+import tempfile
+from urllib.request import urlopen
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+
+def download_binary_file(request):
+    response = urlopen(request)
+    return response_to_temporary_file(response)
+
+
+def determine_extension(response):
+    try:
+        url = response.geturl()
+        parsed_url = urlsplit(url)
+        path = parsed_url.path
+    except AttributeError:
+        path = response.name
+
+    _, ext = splitext(path)
+    return ext
+
+
+def response_to_temporary_file(response):
+    # Try to keep file in memory, but do not exceed FILE_UPLOAD_MAX_MEMORY_SIZE
+    result_file = tempfile.SpooledTemporaryFile(
+        max_size=settings.FILE_UPLOAD_MAX_MEMORY_SIZE,
+        mode="w+b",
+        suffix=".upload%s" % determine_extension(response),
+        dir=settings.FILE_UPLOAD_TEMP_DIR,
+    )
+    # copy the response into a file so it can be read multiple times
+    shutil.copyfileobj(response, result_file)
+
+    result_file.seek(0)
+    return result_file


### PR DESCRIPTION
This PR cleans up tthe settings that where scattered allover oscarapi.
This was needed to introduce yet another setting: FILE_DOWNLOADER_MODULE.
This makes it possible to override the file downloader, so we can make a bit smarter downloaders that listen to cache headers and such. In the __future__ a smart downloader might be contributed to oscarapi, but it needs internal testing first,