### PR TITLE
Fix Django 4 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        django-version: ["3.2", "4.2"]
         oscar-version: ["3.2"]
     steps:
       - name: Download src dir

--- a/oscarapi/middleware.py
+++ b/oscarapi/middleware.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import PermissionDenied
 from django.http.response import HttpResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from oscar.core.loading import get_class
 

--- a/oscarapi/serializers/basket.py
+++ b/oscarapi/serializers/basket.py
@@ -2,7 +2,7 @@
 import logging
 from decimal import Decimal
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 

--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit, parse_qs
 from urllib.error import HTTPError
 from django.conf import settings as django_settings
 from django.db import IntegrityError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
 from django.utils.functional import cached_property

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -2,7 +2,7 @@
 
 import logging
 from copy import deepcopy
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from rest_framework import serializers
 from rest_framework.fields import empty

--- a/oscarapi/signals.py
+++ b/oscarapi/signals.py
@@ -1,3 +1,10 @@
+import django
 from django.dispatch import Signal
 
-oscarapi_post_checkout = Signal(providing_args=["order", "user", "request", "response"])
+
+oscarapi_post_checkout_args = ["order", "user", "request", "response"]
+
+if django.VERSION >= (3, 0):
+    oscarapi_post_checkout = Signal()
+else:
+    oscarapi_post_checkout = Signal(providing_args=oscarapi_post_checkout_args)

--- a/oscarapi/utils/categories.py
+++ b/oscarapi/utils/categories.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from rest_framework.exceptions import NotFound
 

--- a/oscarapi/views/basket.py
+++ b/oscarapi/views/basket.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0632
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from oscar.apps.basket import signals
 from oscar.core.loading import get_model, get_class


### PR DESCRIPTION
When using Django 4 with django-oscar-api there are two kinds of errors:
- Ugettext is Removed in Django 4.0
- Signal kwarg providing_args is Disallowed in Django 4.0

Both are fixed with these commits.