### PR TITLE
Explicit default_auto_field.

### DIFF
--- a/oscarapi/apps.py
+++ b/oscarapi/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class OscarAPIConfig(AppConfig):
     name = "oscarapi"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
This is configurable since Django 3.2, which is already the required version for oscar-api.

see:
https://docs.djangoproject.com/en/3.2/topics/db/models/#automatic-primary-key-fields

Explicitly telling which field to use if good, it avoids a supious migration like:

    $ ./manage.py makemigrations
    Migrations for 'oscarapi':
      /home/mdk/src/django-oscar/.venv/lib/python3.11/site-packages/oscarapi/migrations/0002_alter_apikey_id.py
        - Alter field id on apikey

notice the migration is created in the venv, in oscarapi tree, not in the user project, it won't work anyway.