### PR TITLE
This has been deprecated in 3.1, removed in 4.0.

### DIFF
--- a/oscarapi/signals.py
+++ b/oscarapi/signals.py
@@ -1,10 +1,4 @@
-import django
 from django.dispatch import Signal
 
 
-oscarapi_post_checkout_args = ["order", "user", "request", "response"]
-
-if django.VERSION >= (3, 0):
-    oscarapi_post_checkout = Signal()
-else:
-    oscarapi_post_checkout = Signal(providing_args=oscarapi_post_checkout_args)
+oscarapi_post_checkout = Signal()


### PR DESCRIPTION
django-oscar-api already needs django >= 3.2 in its setup.py so droppin the condition is safe.