### PR TITLE
Fixes handling of null product image attributes

### DIFF
--- a/oscarapi/serializers/fields.py
+++ b/oscarapi/serializers/fields.py
@@ -200,6 +200,8 @@ class AttributeValueField(AttributeFieldBase, serializers.Field):
         elif obj_type == value.attribute.MULTI_OPTION:
             return value.value.values_list("option", flat=True)
         elif obj_type in [value.attribute.FILE, value.attribute.IMAGE]:
+            if not value.value:
+                return None
             url = value.value.url
             request = self.context.get("request", None)
             if request is not None:


### PR DESCRIPTION
Fixes handling of null product image attributes

When an image product attribute is `null`, the product API would throw the 
following exception:

```
ValueError: The 'value_image' attribute has no file associated with it.
  
  […]
  
  File "rest_framework/serializers.py", line 522, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "rest_framework/serializers.py", line 686, in to_representation
    return [
  File "rest_framework/serializers.py", line 687, in <listcomp>
    self.child.to_representation(item) for item in iterable
  File "rest_framework/serializers.py", line 522, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "oscarapi/serializers/fields.py", line 227, in to_representation
    return value.value.url
  File "django/db/models/fields/files.py", line 66, in url
    self._require_file()
  File "django/db/models/fields/files.py", line 41, in _require_file
    raise ValueError(
```

This patch fixes this by checking if the image field has a value before trying 
to generate a URL.