### PR TITLE
bugfix optiongroupserializer missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ test:
 coverage:
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
-	coverage html
+	coverage report -m
+        coverage xml -i
 
 docker-build:
 	 docker build -t oscarapi/test .

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ test:
 coverage:
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
-	coverage report -m
-	coverage xml -i
+	coverage html
 
 docker-build:
 	 docker build -t oscarapi/test .

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ test:
 	python sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
 	python sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
 
-coverage:
-	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
+coverage:	
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
 	coverage report -m
-        coverage xml -i
+	coverage html
+	coverage xml -i
 
 docker-build:
 	 docker build -t oscarapi/test .

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -186,6 +186,7 @@ class PartnerSerializer(OscarHyperlinkedModelSerializer):
 
 
 class OptionSerializer(OscarHyperlinkedModelSerializer):
+    option_group = AttributeOptionGroupSerializer()
     code = serializers.SlugField()
 
     class Meta:

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -186,7 +186,7 @@ class PartnerSerializer(OscarHyperlinkedModelSerializer):
 
 
 class OptionSerializer(OscarHyperlinkedModelSerializer):
-    option_group = AttributeOptionGroupSerializer(required=False)
+    option_group = AttributeOptionGroupSerializer(required=False, allow_null=True)    
     code = serializers.SlugField()
 
     class Meta:

--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -186,7 +186,7 @@ class PartnerSerializer(OscarHyperlinkedModelSerializer):
 
 
 class OptionSerializer(OscarHyperlinkedModelSerializer):
-    option_group = AttributeOptionGroupSerializer()
+    option_group = AttributeOptionGroupSerializer(required=False)
     code = serializers.SlugField()
 
     class Meta:


### PR DESCRIPTION
Added:
`option_group = AttributeOptionGroupSerializer()`

to:

```class OptionSerializer(OscarHyperlinkedModelSerializer):```

in file: oscarapi/serializers/product.py