### PR TITLE
Revert "bugfix optiongroupserializer missing (#344)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ test:
 	python sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
 	python sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
 
-coverage:	
+coverage:
+	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_true
 	coverage run sandbox/manage.py test oscarapi --settings=sandbox.settings.block_admin_api_false
 	coverage report -m
 	coverage xml -i


### PR DESCRIPTION
This reverts commit 8cf7e38783fdc66beb388b7e70e3c694feec9720.