### PR TITLE
[Fix] Child products should not have product class and categories 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
             django-version: "4.2"
           - python-version: "3.11"
             django-version: "3.2"
+          - python-version: "3.9"
+            django-version: "5.2"
           - python-version: "3.8"
             django-version: "5.2"
           - python-version: "3.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,24 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["3.2", "4.2"]
-        oscar-version: ["3.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        django-version: ["3.2", "4.2", "5.2"]
+        oscar-version: ["3.2", "4.0"]
+        exclude:
+          - python-version: "3.13"
+            django-version: "3.2"
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.12"
+            django-version: "3.2"
+          - python-version: "3.12"
+            django-version: "4.2"
+          - python-version: "3.11"
+            django-version: "3.2"
+          - python-version: "3.8"
+            django-version: "5.2"
+          - python-version: "3.8"
+            oscar-version: "4.0"
     steps:
       - name: Download src dir
         uses: actions/download-artifact@v4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
             steps {
                 withPythonEnv('System-CPython-3.10') {
                     withEnv(['PIP_INDEX_URL=https://pypi.uwkm.nl/voxyan/oscar/+simple/']) {
-                        pysh "make install"
+                        pysh "make install-latest"
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ clean:
 	rm -Rf build/
 
 install:
+	pip install -e .[dev]
+
+install-latest:
 	pip install -e .[dev] --upgrade --upgrade-strategy=eager --pre
 
 sandbox: install

--- a/oscarapi/tests/unit/testproduct.py
+++ b/oscarapi/tests/unit/testproduct.py
@@ -886,6 +886,24 @@ class AdminProductSerializerTest(_ProductSerializerTest):
         self.assertEqual(obj.product_class.slug, "testtype")
         self.assertEqual(obj.slug, "new-product")
 
+    def test_create_child_product(self):
+        "Child Products should not have product class and categories"
+        ser = AdminProductSerializer(
+            data={
+                "product_class": "testtype",
+                "slug": "new-product",
+                "categories": ["Clothing"],
+                "structure": "child",
+                "parent": 1,
+            }
+        )
+        self.assertTrue(ser.is_valid(), "Something wrong %s" % ser.errors)
+        obj = ser.save()
+        self.assertEqual(obj.pk, 5, "Should be new object, with a high pk")
+        self.assertEqual(obj.product_class, None)
+        self.assertFalse(obj.categories.exists())
+        self.assertEqual(obj.slug, "new-product")
+
     def test_modify_product(self):
         "We should a able to change product fields."
         product = Product.objects.get(pk=3)


### PR DESCRIPTION
Ignores categories, product_class and children if they are added in the requests to create or update child products.