### PR TITLE
Resolve 500 error when creating product with null attribute value

### DIFF
--- a/oscarapi/serializers/product.py
+++ b/oscarapi/serializers/product.py
@@ -276,7 +276,7 @@ class ProductAttributeValueListSerializer(UpdateListSerializer):
 
     def get_value(self, dictionary):
         values = super(ProductAttributeValueListSerializer, self).get_value(dictionary)
-        if values is empty:
+        if not values or values is empty:
             return values
 
         product_class, parent = getitems(dictionary, "product_class", "parent")

--- a/oscarapi/tests/unit/testproduct.py
+++ b/oscarapi/tests/unit/testproduct.py
@@ -1750,6 +1750,13 @@ class TestProductAdmin(APITest):
         )
         self.response.assertStatusEqual(404)
 
+    def test_post_product_with_null_attributes(self):
+        "Test creating a product with null attributes should return a 400 Bad Request"
+        self.login("admin", "admin")
+        data = {"product_class": "testtype", "slug": "test", "attributes": None}
+        self.response = self.post("admin-product-list", **data)
+        self.response.assertStatusEqual(400)
+
     def test_put_child(self):
         self.login("admin", "admin")
         url = reverse("admin-product-detail", args=(2,))


### PR DESCRIPTION
##Description 
This update prevents potential 500 errors by properly handling null or empty values in ProductAttributeValueSerializer. 
Includes a test case to ensure serializer stability with null attribute values.

Resolves: https://github.com/django-oscar/django-oscar-api/issues/342