### PR TITLE
Allow imageURLField to be imported dynamically

### DIFF
--- a/oscarapi/serializers/utils.py
+++ b/oscarapi/serializers/utils.py
@@ -8,8 +8,9 @@ from rest_framework import serializers
 import oscar.models.fields
 
 from oscarapi.utils.exists import construct_id_filter
-from .fields import ImageUrlField
+from oscarapi.utils.loading import get_api_classes
 
+[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
 logger = logging.getLogger(__name__)
 
 

--- a/oscarapi/serializers/utils.py
+++ b/oscarapi/serializers/utils.py
@@ -2,15 +2,12 @@ import logging
 from django.db import models
 from django.db.models.manager import Manager
 from django.db.models.constants import LOOKUP_SEP
-
 from rest_framework import serializers
-
 import oscar.models.fields
-
 from oscarapi.utils.exists import construct_id_filter
-from oscarapi.utils.loading import get_api_classes
+from oscarapi.utils.loading import get_api_class
 
-[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
+ImageUrlField = get_api_class("serializers.fields", "ImageUrlField")
 logger = logging.getLogger(__name__)
 
 

--- a/oscarapi/tests/unit/testserializers.py
+++ b/oscarapi/tests/unit/testserializers.py
@@ -1,9 +1,9 @@
 from django.db import models
 from django.test import TestCase
 from rest_framework.fields import ImageField
-from oscarapi.utils.loading import get_api_classes
+from oscarapi.utils.loading import get_api_class
 
-[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
+ImageUrlField = get_api_class("serializers.fields", "ImageUrlField")
 
 
 class SerializerstTest(TestCase):

--- a/oscarapi/tests/unit/testserializers.py
+++ b/oscarapi/tests/unit/testserializers.py
@@ -1,7 +1,9 @@
 from django.db import models
 from django.test import TestCase
-from oscarapi.serializers.utils import ImageUrlField
 from rest_framework.fields import ImageField
+from oscarapi.utils.loading import get_api_classes
+
+[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
 
 
 class SerializerstTest(TestCase):

--- a/oscarapi/utils/attributes.py
+++ b/oscarapi/utils/attributes.py
@@ -5,7 +5,9 @@ from rest_framework.fields import MISSING_ERROR_MESSAGE
 from rest_framework.exceptions import ErrorDetail
 from oscarapi.utils.loading import get_api_class
 from oscarapi.serializers import fields as oscarapi_fields
+from oscarapi.utils.loading import get_api_classes
 
+[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
 attribute_details = operator.itemgetter("code", "value")
 entity_internal_value = get_api_class("serializers.hooks", "entity_internal_value")
 
@@ -57,7 +59,7 @@ class AttributeFieldBase:
         elif attribute.type == attribute.ENTITY:
             internal_value = entity_internal_value(attribute, value)
         elif attribute.type in [attribute.IMAGE, attribute.FILE]:
-            image_field = oscarapi_fields.ImageUrlField()
+            image_field = ImageUrlField()
             # pylint: disable=protected-access
             image_field._context = self.context
             internal_value = image_field.to_internal_value(value)

--- a/oscarapi/utils/attributes.py
+++ b/oscarapi/utils/attributes.py
@@ -4,10 +4,8 @@ from rest_framework import serializers
 from rest_framework.fields import MISSING_ERROR_MESSAGE
 from rest_framework.exceptions import ErrorDetail
 from oscarapi.utils.loading import get_api_class
-from oscarapi.serializers import fields as oscarapi_fields
-from oscarapi.utils.loading import get_api_classes
 
-[ImageUrlField] = get_api_classes("serializers.fields", ["ImageUrlField"])
+ImageUrlField = get_api_class("serializers.fields", "ImageUrlField")
 attribute_details = operator.itemgetter("code", "value")
 entity_internal_value = get_api_class("serializers.hooks", "entity_internal_value")
 


### PR DESCRIPTION
This change will be it convenient to further customize `ImageUrlField` in the `customapp.serializers.fields` class. With the initial setup this was not possible since teh changed areas hard coded import `ImageUrlField` from `oscarapi.fields` instead of using the dynamic import `get_api_class` method.